### PR TITLE
Fix unit tests for scripts

### DIFF
--- a/dbprocessing/DButils.py
+++ b/dbprocessing/DButils.py
@@ -780,17 +780,27 @@ class DButils(object):
                    mission_name,
                    rootdir,
                    incoming_dir,
-                   codedir,
-                   inspectordir,
-                   errordir):
+                   codedir=None,
+                   inspectordir=None,
+                   errordir=None):
         """
         Add a mission to the database
+
+        Optional directories which are not specified will be inserted
+        into the database as nulls, and the default will be determined
+        at runtime.
 
         :param mission_name: the name of the mission
         :type mission_name: str
         :param rootdir: the root directory of the mission
         :type rootdir: str
-
+        :param str incoming_dir: directory for incoming files
+        :param str codedir: directory containing codes (optional; see
+                            :meth:`getCodeDirectory`)
+        :param str inspectordir: directory containing product inspectors
+                                 (optional; see :meth:`getInspectorDirectory`)
+        :param str errordir: directory to contain error files (optional;
+                             see :meth:`getErrorPath`)
         """
         mission_name = str(mission_name)
         rootdir = str(rootdir)
@@ -802,12 +812,15 @@ class DButils(object):
         m1.mission_name = mission_name
         m1.rootdir = rootdir.replace('{MISSION}', mission_name)
         m1.incoming_dir = incoming_dir.replace('{MISSION}', mission_name)
-        m1.codedir = codedir.replace('{MISSION}', mission_name)
-        m1.inspectordir = inspectordir.replace('{MISSION}', mission_name)
+        m1.codedir = None if codedir is None \
+                     else codedir.replace('{MISSION}', mission_name)
+        m1.inspectordir = None if inspectordir is None\
+                          else inspectordir.replace('{MISSION}', mission_name)
 
         if hasattr(m1, 'newest_version'):
             # Old DBs will not have this, new ones will
-            m1.errordir = errordir
+            m1.errordir = None if errordir is None \
+                          else errordir.replace('{MISSION}', mission_name)
 
         self.session.add(m1)
         self.commitDB()

--- a/scripts/addFromConfig.py
+++ b/scripts/addFromConfig.py
@@ -17,6 +17,7 @@
 # <- add the prod
 # <- create the inst_prod link
 
+import collections
 import ConfigParser
 import os
 import shutil
@@ -30,9 +31,13 @@ from sqlalchemy.orm.exc import NoResultFound
 from dbprocessing import DButils
 
 expected = ['mission', 'satellite', 'instrument', 'product', 'process']
+# All keywords that are permitted in a section (optional or required)
 expected_keyword = { }
+# Subset of expected_keyword that are permitted not required
+optional_keyword = collections.defaultdict(list)
 expected_keyword['mission'] = ['incoming_dir', 'mission_name', 'rootdir',
                                'codedir', 'inspectordir', 'errordir']
+optional_keyword['mission'] = ['codedir', 'inspectordir', 'errordir']
 expected_keyword['satellite'] = ['satellite_name']
 expected_keyword['instrument'] = ['instrument_name']
 expected_keyword['product'] = ['product_name', 'relative_path',
@@ -103,12 +108,13 @@ def _keysCheck(conf, section):
     else:
         section_ex = section
     keys = expected_keyword[section_ex]
+    optional = optional_keyword[section_ex]
     for k in keys:
-        if k.startswith('required_input') or k.startswith('optional_input'):
+        if k.startswith(('required_input', 'optional_input')) \
+           or k in optional:
             continue
-        else:
-            if k not in conf[section]:
-                raise (ValueError('Required key: "{0}" was not found in [{1}] section'.format(k, section)))
+        if k not in conf[section]:
+            raise (ValueError('Required key: "{0}" was not found in [{1}] section'.format(k, section)))
 
 
 def _keysRemoveExtra(conf, section):

--- a/tests_scripts/test_CreateDB.py
+++ b/tests_scripts/test_CreateDB.py
@@ -5,10 +5,12 @@ import os
 import tempfile
 import unittest
 import subprocess
+import sys
 
 from dbprocessing import DBfile
 from dbprocessing import DButils
-from ..scripts import CreateDB
+sys.path.append('../scripts') # Add scripts dir to the python path for the import
+import CreateDB
 
 filename = 'test_file.txt'
 

--- a/tests_scripts/test_CreateDB.py
+++ b/tests_scripts/test_CreateDB.py
@@ -2,6 +2,7 @@
 
 import datetime
 import os
+import os.path
 import tempfile
 import unittest
 import subprocess
@@ -9,7 +10,9 @@ import sys
 
 from dbprocessing import DBfile
 from dbprocessing import DButils
-sys.path.append('../scripts') # Add scripts dir to the python path for the import
+# Add scripts dir to the python path for the import
+sys.path.append(os.path.abspath(os.path.join(
+    os.path.dirname(__file__), '..', 'scripts')))
 import CreateDB
 
 filename = 'test_file.txt'

--- a/tests_scripts/test_addFromConfig.py
+++ b/tests_scripts/test_addFromConfig.py
@@ -10,12 +10,76 @@ from addFromConfig import readconfig, _sectionCheck, _keysCheck, _keysRemoveExtr
 class addFromConfig(unittest.TestCase):
     """Tests for addFromConfig script"""
 
+    longMessage = True
+    maxDiff = None
+
     def test_readconfig(self):
         """Does readconfig match the expected output"""
 
         conf = readconfig('testing_configs/testDB.conf')
         # Regression testing, just copy-pasted from the actual output
-        ans = {'satellite': {'satellite_name': '{MISSION}-a'}, 'product_concat': {'inspector_output_interface': '1', 'inspector_version': '1.0.0', 'inspector_arguments': '-q', 'format': 'testDB_{nnn}.cat', 'level': '1.0', 'product_description': '', 'relative_path': 'L1', 'inspector_newest_version': 'True', 'inspector_relative_path': 'codes/inspectors', 'inspector_date_written': '2016-05-31', 'inspector_filename': 'rot13_L1.py', 'inspector_description': 'Level 1', 'inspector_active': 'True', 'product_name': '{MISSION}_rot13_L1'}, 'product_rot13': {'inspector_output_interface': '1', 'inspector_version': '1.0.0', 'inspector_arguments': '-q', 'format': 'testDB_{nnn}.rot', 'level': '2.0', 'product_description': '', 'relative_path': 'L2', 'inspector_newest_version': 'True', 'inspector_relative_path': 'codes/inspectors', 'inspector_date_written': '2016-05-31', 'inspector_filename': 'rot13_L2.py', 'inspector_description': 'Level 2', 'inspector_active': 'True', 'product_name': '{MISSION}_rot13_L2'}, 'mission': {'incoming_dir': 'L0', 'rootdir': '/home/myles/dbprocessing/test_DB', 'mission_name': 'testDB'}, 'instrument': {'instrument_name': 'rot13'}, 'process_rot13_L1-L2': {'code_cpu': '1', 'code_start_date': '2010-09-01', 'code_stop_date': '2020-01-01', 'code_filename': 'run_rot13_L1toL2.py', 'code_relative_path': 'scripts', 'required_input1': 'product_concat', 'code_version': '1.0.0', 'process_name': 'rot_L1toL2', 'code_output_interface': '1', 'code_newest_version': 'True', 'code_date_written': '2016-05-31', 'code_description': 'Python L1->L2', 'output_product': 'product_rot13', 'code_active': 'True', 'code_arguments': '', 'extra_params': '', 'output_timebase': 'FILE', 'code_ram': '1'}}
+        ans = {
+            'satellite': {'satellite_name': '{MISSION}-a'},
+            'product_concat': {
+                'inspector_output_interface': '1',
+                'inspector_version': '1.0.0',
+                'inspector_arguments': '-q',
+                'format': 'testDB_{nnn}.cat',
+                'level': '1.0',
+                'product_description': '',
+                'relative_path': 'L1',
+                'inspector_newest_version': 'True',
+                'inspector_relative_path': 'codes/inspectors',
+                'inspector_date_written': '2016-05-31',
+                'inspector_filename': 'rot13_L1.py',
+                'inspector_description': 'Level 1',
+                'inspector_active': 'True',
+                'product_name': '{MISSION}_rot13_L1'},
+            'product_rot13': {
+                'inspector_output_interface': '1',
+                'inspector_version': '1.0.0',
+                'inspector_arguments': '-q',
+                'format': 'testDB_{nnn}.rot',
+                'level': '2.0',
+                'product_description': '',
+                'relative_path': 'L2',
+                'inspector_newest_version': 'True',
+                'inspector_relative_path': 'codes/inspectors',
+                'inspector_date_written': '2016-05-31',
+                'inspector_filename': 'rot13_L2.py',
+                'inspector_description': 'Level 2',
+                'inspector_active': 'True',
+                'product_name': '{MISSION}_rot13_L2'},
+            'mission': {
+                'incoming_dir': 'L0',
+                'rootdir': '/home/myles/dbprocessing/test_DB',
+                'mission_name': 'testDB'},
+            'instrument': {'instrument_name': 'rot13'},
+            'process_rot13_L1-L2': {'code_cpu': '1',
+                'code_start_date': '2010-09-01',
+                'code_stop_date': '2020-01-01',
+                'code_filename': 'run_rot13_L1toL2.py',
+                'code_relative_path': 'scripts',
+                'required_input1': 'product_concat',
+                'code_version': '1.0.0',
+                'process_name': 'rot_L1toL2',
+                'code_output_interface': '1',
+                'code_newest_version': 'True',
+                'code_date_written': '2016-05-31',
+                'code_description': 'Python L1->L2',
+                'output_product': 'product_rot13',
+                'code_active': 'True',
+                'code_arguments': '',
+                'extra_params': '',
+                'output_timebase': 'FILE',
+                'code_ram': '1'}
+        }
+        key_diff = set(ans.keys()).symmetric_difference(conf.keys())
+        if key_diff:
+            self.fail('Keys in only one of actual/expected: '
+                      + ', '.join(key_diff))
+        for k in ans:
+            self.assertEqual(ans[k], conf[k], k)
         self.assertEqual(ans, conf)
 
     def test_sectionCheck_Valid(self):

--- a/tests_scripts/test_addFromConfig.py
+++ b/tests_scripts/test_addFromConfig.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python
 
+import os.path
 import sys
 import tempfile
 import unittest
 
-sys.path.append('../scripts') # Add scripts dir to the python path for the import
+# Add scripts dir to the python path for the import
+thisdir = os.path.dirname(__file__)
+sys.path.append(os.path.abspath(os.path.join(
+    thisdir, '..', 'scripts')))
 from addFromConfig import readconfig, _sectionCheck, _keysCheck, _keysRemoveExtra, _keysPresentCheck, _fileTest
 
 class addFromConfig(unittest.TestCase):
@@ -16,7 +20,8 @@ class addFromConfig(unittest.TestCase):
     def test_readconfig(self):
         """Does readconfig match the expected output"""
 
-        conf = readconfig('testing_configs/testDB.conf')
+        conf = readconfig(os.path.join(
+            thisdir, 'testing_configs', 'testDB.conf'))
         # Regression testing, just copy-pasted from the actual output
         ans = {
             'satellite': {'satellite_name': '{MISSION}-a'},
@@ -85,24 +90,28 @@ class addFromConfig(unittest.TestCase):
     def test_sectionCheck_Valid(self):
         """Make sure no Exceptions are thrown for a valid config"""
         try:
-            conf = readconfig('testing_configs/testDB.conf')
+            conf = readconfig(os.path.join(
+                thisdir, 'testing_configs', 'testDB.conf'))
             _sectionCheck(conf)
         except Exception as e:
             self.fail(e)
 
     def test_sectionCheck_MissingMission(self):
         """Make sure it notices Mission is missing"""
-        conf = readconfig('testing_configs/testDB_noMission.conf')
+        conf = readconfig(os.path.join(
+            thisdir, 'testing_configs', 'testDB_noMission.conf'))
         self.assertRaises(ValueError, _sectionCheck, conf)
 
     def test_sectionCheck_FakeSection(self):
         """Make sure it notices there's a fake section"""
-        conf = readconfig('testing_configs/testDB_fakeSection.conf')
+        conf = readconfig(os.path.join(
+            thisdir, 'testing_configs', 'testDB_fakeSection.conf'))
         self.assertRaises(ValueError, _sectionCheck, conf)
 
     def test_keysCheck_Valid(self):
         """Make sure no Exceptions are thrown for a valid config"""
-        conf = readconfig('testing_configs/testDB.conf')
+        conf = readconfig(os.path.join(
+            thisdir, 'testing_configs', 'testDB.conf'))
         try:
             for key in conf.keys():
                 _keysCheck(conf, key)
@@ -111,42 +120,49 @@ class addFromConfig(unittest.TestCase):
 
     def test_keysCheck_MissingRequired(self):
         """Make sure it notices missing required keys"""
-        conf = readconfig('testing_configs/testDB_missingKey.conf')
+        conf = readconfig(os.path.join(
+            thisdir, 'testing_configs', 'testDB_missingKey.conf'))
         self.assertRaises(ValueError, _keysCheck, conf, 'mission')
 
     def test_keysRemoveExtra(self):
         """Make sure it removes extra keys"""
-        validResult = readconfig('testing_configs/testDB.conf')
+        validResult = readconfig(os.path.join(
+            thisdir, 'testing_configs', 'testDB.conf'))
 
-        conf = _keysRemoveExtra(readconfig('testing_configs/testDB_extraKey.conf'), 'mission')
+        conf = _keysRemoveExtra(readconfig(os.path.join(
+            thisdir, 'testing_configs', 'testDB_extraKey.conf')), 'mission')
         self.assertEqual(validResult['mission'], conf)
 
     def test_keysPresentCheck_Valid(self):
         try:
-            conf = readconfig('testing_configs/testDB.conf')
+            conf = readconfig(os.path.join(
+                thisdir, 'testing_configs', 'testDB.conf'))
             _keysPresentCheck(conf)
         except Exception as e:
             self.fail(e)
 
     def test_keysPresentCheck_Invalid(self):
-        conf = readconfig('testing_configs/testDB_missingProduct.conf')
+        conf = readconfig(os.path.join(
+            thisdir, 'testing_configs', 'testDB_missingProduct.conf'))
         self.assertRaises(ValueError, _keysPresentCheck, conf)
 
     def test_keysPresentCheck_Trigger(self):
         try:
-            conf = readconfig('testing_configs/testDB_trigger.conf')
+            conf = readconfig(os.path.join(
+                thisdir, 'testing_configs', 'testDB_trigger.conf'))
             _keysPresentCheck(conf)
         except Exception as e:
             self.fail(e)
 
     def test_fileTest_Valid(self):
         try:
-            _fileTest('testing_configs/testDB.conf')
+            _fileTest(os.path.join(thisdir, 'testing_configs', 'testDB.conf'))
         except Exception as e:
             self.fail(e)
 
     def test_fileTest_Invalid(self):
-        self.assertRaises(ValueError, _fileTest, 'testing_configs/testDB_duplicateSection.conf')
+        self.assertRaises(ValueError, _fileTest, os.path.join(
+            thisdir, 'testing_configs', 'testDB_duplicateSection.conf'))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests_scripts/test_addFromConfig.py
+++ b/tests_scripts/test_addFromConfig.py
@@ -60,7 +60,7 @@ class addFromConfig(unittest.TestCase):
                 'code_stop_date': '2020-01-01',
                 'code_filename': 'run_rot13_L1toL2.py',
                 'code_relative_path': 'scripts',
-                'required_input1': 'product_concat',
+                'required_input1': ('product_concat', 0, 0),
                 'code_version': '1.0.0',
                 'process_name': 'rot_L1toL2',
                 'code_output_interface': '1',

--- a/unit_tests/test_DButils.py
+++ b/unit_tests/test_DButils.py
@@ -64,6 +64,27 @@ class DBUtilsEmptyTests(TestSetup):
     def test_empty_mission_dir(self):
         self.assertIsNone(self.dbu.getMissionDirectory())
 
+    def test_addMissionOptionals(self):
+        """Test addMission excluding optional inputs"""
+        self.assertEqual(self.dbu.addMission(
+            'name', '/rootdir/', '/root/incoming'), 1)
+        miss = self.dbu.getEntry('Mission', 1)
+        self.assertEqual(1, miss.mission_id)
+        self.assertTrue(miss.codedir is None)
+        self.assertTrue(miss.errordir is None)
+        self.assertTrue(miss.inspectordir is None)
+        self.assertEqual('/rootdir/', miss.rootdir)
+        self.assertEqual('/root/incoming', miss.incoming_dir)
+
+        # These are not exactly test of just the add, but they behave
+        # differently with this different add.
+        # Reload the mission
+        self.dbu.closeDB()
+        self.dbu = DButils.DButils(self.sqlworking)
+        self.assertEqual('/rootdir', self.dbu.getCodeDirectory())
+        self.assertEqual('/rootdir/errors', self.dbu.getErrorPath())
+        self.assertEqual('/rootdir', self.dbu.getInspectorDirectory())
+
 
 class DBUtilsOtherTests(TestSetup):
     """Tests that are not processqueue or get or add"""


### PR DESCRIPTION
The `tests_scripts` directory contains unit tests for the scripts. Unfortunately these hadn't been updated in awhile and were failing. This PR fixes them, as well as making a small change so addFromConfig works properly with older config files (ones that don't explicitly specify code, inspector, and error directories.)