### PR TITLE
Fix handling of inspector regex for ECT

### DIFF
--- a/dbprocessing/DBstrings.py
+++ b/dbprocessing/DBstrings.py
@@ -49,6 +49,8 @@ class DBformatter(string.Formatter):
         'VERSION': ('{VERSION}', '\d+\.\d+\.\d+'),
         'DATE': ('{DATE}', '(19|2\d)\d\d(0\d|1[0-2])[0-3]\d'),
         'datetime': ('{datetime}', '(19|2\d)\d\d(0\d|1[0-2])[0-3]\d'),
+        'mday': ('{mday:d}', '-?\d+'),
+        'APID': ('{APID:x}', '[\da-fA-F]+'),
         '??': ('{??}', '..'),
         '???': ('{???}', '...'),
         '????': ('{????}', '....'),

--- a/unit_tests/test_DBstrings.py
+++ b/unit_tests/test_DBstrings.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 __author__ = 'Jonathan Niehof <jniehof@lanl.gov>'
 
 import datetime
+import re
 import unittest
 
 from dbprocessing import DBstrings
@@ -148,6 +149,30 @@ class DBFormatterTests(unittest.TestCase):
             ]
         for i, o in zip(inputs, outputs):
             self.assertEqual(o, self.fmtr.format(i[0], **i[1]))
+
+    def testAPID(self):
+        """Test regex and format expansion with an APID in the string"""
+        fmt = 'ect_rbspa_{nnnn}_{APID}_{nn}.ptp.gz'
+        expected = 'ect_rbspa_(\d\d\d\d)_([\da-fA-F]+)_(\d\d).ptp.gz'
+        self.assertEqual(expected, self.fmtr.re(fmt))
+        # Does this regex actually match a filename?
+        self.assertTrue(re.match(
+            '^' + expected + '$',
+            'ect_rbspa_0377_34b_02.ptp.gz'))
+        self.assertEqual(
+            'ect_rbspa_{nnnn}_{APID:x}_{nn}.ptp.gz', self.fmtr.expand_format(fmt))
+
+    def testMissionDayRegex(self):
+        """Test regex and format expansion  with mission day in the string"""
+        fmt = 'rbspa_int_ect-mageisLOW-ns-L05_{mday}_v{VERSION}.cdf'
+        expected = 'rbspa_int_ect-mageisLOW-ns-L05_(-?\d+)_v(\d+\.\d+\.\d+).cdf'
+        self.assertEqual(expected, self.fmtr.re(fmt))
+        self.assertTrue(re.match(
+            '^' + expected + '$',
+            'rbspa_int_ect-mageisLOW-ns-L05_0376_v3.0.0.cdf'))
+        self.assertEqual(
+            'rbspa_int_ect-mageisLOW-ns-L05_{mday:d}_v{VERSION}.cdf',
+            self.fmtr.expand_format(fmt))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
@balarsen noticed that the inspector regex calculation was failing on some ECT files. These had file format arguments {APID} and {mday}, which dbprocessing has no special handling for, but it was quietly passing through to the inspector and the inspector was doing nice things with it. Once dbprocessing started calculating a regex from the file format, this failed.

This PR fixes things twice over:
1. It adds a regular expression for APID and mission day (mday). The APID is assumed lower-case hex, but we can recognize mix upper/lower. The mission day is assumed decimal but can be negative (we ran into that in the past...)
2. For any other file format strings that dbp doesn't recognize, it now replaces them with a catch-all regex when making the regex for the inspector.

Given that we don't do any other special handling for apid and mission day (and indeed most of the mission day file formats at higher levels use {nnnn}), I'd be okay with taking out the bits in 1, but it's also a nice-to-have.

Also, the tests for the inspector have to be run with a directory specification; if in the directory, do:
`python ./test_Inspector.py`
This is being fixed on a different branch but didn't want to hold this up (or introduce conflicts later.)