### PR TITLE
test_checkIncoming update to guarantee directory state (Closes #17)

### DIFF
--- a/unit_tests/test_DButils.py
+++ b/unit_tests/test_DButils.py
@@ -120,14 +120,19 @@ class DBUtilsOtherTests(TestSetup):
 
     def test_checkIncoming(self):
         """checkIncoming"""
-        self.assertFalse(self.dbu.checkIncoming())
         e = self.dbu.getEntry('Mission', 1)
-        e.incoming_dir = os.path.abspath(os.path.dirname(__file__))
-        self.dbu.session.add(e)
-        self.dbu.commitDB()
-        inc_files = self.dbu.checkIncoming()
-        self.assertTrue(inc_files)
-        self.assertTrue(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'test_DButils.py') in inc_files)
+        td = tempfile.mkdtemp()
+        try:
+            e.incoming_dir = td
+            self.assertFalse(self.dbu.checkIncoming())
+            fnames = [os.path.join(td, f) for f in ['test', 'test2', '3test']]
+            for f in fnames:
+                open(f, 'w').close()
+            inc_files = self.dbu.checkIncoming()
+            self.assertTrue(inc_files)
+            self.assertEqual(sorted(fnames), sorted(inc_files))
+        finally:
+            shutil.rmtree(td)
 
     def test_currentlyProcessing(self):
         """currentlyProcessing"""


### PR DESCRIPTION
test_DButils test_checkIncoming assumed that the incoming directory by default didn't exist, and thus would show no files to process. This wasn't guaranteed to be the case (#17). This PR sets the incoming dir before testing for empty, and then makes some files in that directory for a deterministic non-empty test (before it used the unit_tests directory and thus depended somewhat on what other files were in there.) Closes #17.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] (N/A) Major new functionality has appropriate Sphinx documentation
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] ((N/A) New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked in the description (e.g. `See issue #` or `Closes #`)
