### PR TITLE
Fix _getRequiredProducts/getInputProductID on old DB (Closes #20)

### DIFF
--- a/dbprocessing/DButils.py
+++ b/dbprocessing/DButils.py
@@ -14,6 +14,7 @@ from collections import namedtuple
 from operator import itemgetter, attrgetter
 
 import sqlalchemy
+import sqlalchemy.sql.expression
 from sqlalchemy import Table
 from sqlalchemy.orm import mapper
 from sqlalchemy.orm import sessionmaker
@@ -1708,13 +1709,17 @@ class DButils(object):
         :return: list of input_product_ids
         :rtype: list
         """
+        columns = [self.Productprocesslink.input_product_id,
+                   self.Productprocesslink.optional]
         if range:
-            sq = self.session.query(self.Productprocesslink.input_product_id, self.Productprocesslink.optional,
-                self.Productprocesslink.yesterday, self.Productprocesslink.tomorrow)\
-                .filter_by(process_id=process_id).all()
-        else:
-            sq = self.session.query(self.Productprocesslink.input_product_id, self.Productprocesslink.optional)\
-                .filter_by(process_id=process_id).all()
+            columns.extend(
+                [self.Productprocesslink.yesterday,
+                 self.Productprocesslink.tomorrow]
+                if hasattr(self.Productprocesslink, 'yesterday') else
+                [sqlalchemy.sql.expression.literal(0).label('yesterday'),
+                 sqlalchemy.sql.expression.literal(0).label('tomorrow')]
+            )
+        sq = self.session.query(*columns).filter_by(process_id=process_id).all()
         return sq
 
     def getFiles(self,

--- a/unit_tests/test_DButils.py
+++ b/unit_tests/test_DButils.py
@@ -531,6 +531,14 @@ class DBUtilsGetTests(TestSetup):
         self.assertFalse(self.dbu.getInputProductID(2343))
         self.assertEqual([], self.dbu.getInputProductID(2343))
 
+    def test_getInputProductIDOldDB(self):
+        """getInputProductID, asking for yesterday/tomorrow on old DB"""
+        res = self.dbu.getInputProductID(2, True)
+        self.assertEqual(
+            [(22, False, 0, 0), (43, False, 0, 0),
+             (84, False, 0, 0), (90, True, 0, 0)],
+            res)
+
     def test_getFilesEndDate(self):
         """getFiles with only end date specified"""
         val = self.dbu.getFiles(endDate='2013-09-14', product=138)


### PR DESCRIPTION
_getRequiredProducts called getInputProductID with a particular kwarg forcing return of the yesterday-count and tomorrow-count, which aren't in the old database. This PR tests the call with this kwarg and fixes on old databases, returning 0 for both yesterday and tomorrow, so downstream code should work just as it does for newer databases. Closes #20.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] (N/A) Major new functionality has appropriate Sphinx documentation
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked in the description (e.g. `See issue #` or `Closes #`)
