### PR TITLE
DBRunner enhancements for ingest, update-only, force (Closes #9)

### DIFF
--- a/dbprocessing/runMe.py
+++ b/dbprocessing/runMe.py
@@ -384,14 +384,15 @@ class runMe(object):
                 if codechange: # if the code did change maybe we have a unique
                     DBlogging.dblogger.debug("Code did change for file: {0}".format(self.filename))
                     continue
-                
-                parentchange = self._parentsChanged(f_id_db)
-                if parentchange is None: # this is an inconsistency mark it and move on
-                    DBlogging.dblogger.info("Parent was None for file: {0}".format(self.filename))
-                    break
-                if parentchange:
-                    DBlogging.dblogger.debug("Parent did change for file: {0}".format(self.filename))
-                    continue
+
+                if self.input_files: # Parent check only if process takes input
+                    parentchange = self._parentsChanged(f_id_db)
+                    if parentchange is None: # this is an inconsistency mark it and move on
+                        DBlogging.dblogger.info("Parent was None for file: {0}".format(self.filename))
+                        break
+                    if parentchange:
+                        DBlogging.dblogger.debug("Parent did change for file: {0}".format(self.filename))
+                        continue
                 
                 DBlogging.dblogger.debug("Jumping out of runme, not going to run anything".format())
 

--- a/developer/README.txt
+++ b/developer/README.txt
@@ -1,0 +1,7 @@
+This directory contains miscellaneous bits for sharing between developers.
+It is not included in the source tarball or binary distributions.
+
+functionals:
+    Set ups for task-specific functional tests or test configurations. Should
+    be kept minimal and not include databases (databases should be created
+    from configuration file.) Include a README.

--- a/developer/functionals/no_inputs/README.txt
+++ b/developer/functionals/no_inputs/README.txt
@@ -1,0 +1,22 @@
+Functional test setup for processes that don't require inputs.
+
+It's recommended to make a copy of this directory before messing with it,
+and be careful not to commit scratch files...
+
+Setup:
+CreateDB.py no_inputs.sqlite
+addFromConfig.py -m no_inputs.sqlite ./no_inputs.conf
+mkdir root/data root/dbp_incoming root/dbp_codes/errors
+chmod u+x root/dbp_codes/scripts/inputless_v1.0.0/inputless_v1.0.0.py
+
+Run to just make files in the local directory:
+DBRunner.py -m ./no_inputs.sqlite -s 20100101 -e 20100102 1
+
+Run so as to ingest them:
+DBRunner.py -m ./no_inputs.sqlite -s 20100101 -e 20100102 1 -i -u
+ls root/data/ # Should be files there
+printProcessQueue.py ./no_inputs.sqlite # Should be two on queue
+ProcessQueue.py -p -m ./no_inputs.sqlite # Nothing to do
+
+Make sure don't run again; they're up to date:
+DBRunner.py -m ./no_inputs.sqlite -s 20100101 -e 20100102 1 -u

--- a/developer/functionals/no_inputs/README.txt
+++ b/developer/functionals/no_inputs/README.txt
@@ -20,3 +20,9 @@ ProcessQueue.py -p -m ./no_inputs.sqlite # Nothing to do
 
 Make sure don't run again; they're up to date:
 DBRunner.py -m ./no_inputs.sqlite -s 20100101 -e 20100102 1 -u
+
+Bump the code version:
+python ./inc_code_version.py
+
+Make sure get new versions of files:
+DBRunner.py -m ./no_inputs.sqlite -s 20100101 -e 20100102 1 -u -i

--- a/developer/functionals/no_inputs/README.txt
+++ b/developer/functionals/no_inputs/README.txt
@@ -12,6 +12,9 @@ chmod u+x root/dbp_codes/scripts/inputless_v1.0.0/inputless_v1.0.0.py
 Run to just make files in the local directory:
 DBRunner.py -m ./no_inputs.sqlite -s 20100101 -e 20100102 1
 
+Try same thing but process name:
+DBRunner.py -m ./no_inputs.sqlite -s 20100101 -e 20100102 inputless
+
 Run so as to ingest them:
 DBRunner.py -m ./no_inputs.sqlite -s 20100101 -e 20100102 1 -i -u
 ls root/data/ # Should be files there

--- a/developer/functionals/no_inputs/inc_code_version.py
+++ b/developer/functionals/no_inputs/inc_code_version.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+"""Increment the version of the only code in the database, for func test"""
+
+import os
+import os.path
+import shutil
+
+import dbprocessing.DButils
+
+
+dbu = dbprocessing.DButils.DButils('no_inputs.sqlite')
+codes = dbu.getAllCodes()
+# Should only be the one active code!
+assert len(codes) == 1
+oldcode = codes[0]['code']
+del codes
+newcode = dbu.Code()
+for k in dir(newcode):
+    if not k.startswith('_'):
+        setattr(newcode, k, getattr(oldcode, k))
+newcode.code_id = None
+newcode.quality_version = oldcode.quality_version + 1
+dbu.session.add(newcode)
+dbu.commitDB()
+# Old code no longer active
+dbu.updateCodeNewestVersion(oldcode.code_id)
+
+# And move the actual files around
+oldver = '{}.{}.{}'.format(oldcode.interface_version, oldcode.quality_version,
+                           oldcode.revision_version)
+newver = '{}.{}.{}'.format(oldcode.interface_version, newcode.quality_version,
+                           oldcode.revision_version)
+oldpath  = os.path.join('root', 'dbp_codes', 'scripts',
+                        'inputless_v{}'.format(oldver),
+                        'inputless_v{}.py'.format(oldver))
+newpath = os.path.join('root', 'dbp_codes', 'scripts',
+                        'inputless_v{}'.format(newver))
+os.mkdir(newpath)
+shutil.copy2(oldpath, os.path.join(newpath, 'inputless_v{}.py'.format(newver)))

--- a/developer/functionals/no_inputs/no_inputs.conf
+++ b/developer/functionals/no_inputs/no_inputs.conf
@@ -1,0 +1,136 @@
+# Honored database substitutions used as {Y}{MILLI}{PRODUCT}
+#       Y: 4 digit year
+#       m: 2 digit month
+#       b: 3 character month (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)
+#       d: 2 digit day
+#       y: 2 digit year
+#       j: 3 digit day of year
+#       H: 2 digit hour (24-hour time)
+#       M: 2 digit minute
+#       S: 2 digit second
+#       MILLI: 3 digit millisecond
+#       MICRO: 3 digit microsecond
+#       QACODE: the QA code (ok|ignore|problem)
+#       VERSION: version string, interface.quality.revision
+#       DATE: the UTC date from a file, same as Ymd
+#       MISSION: the mission name from the db
+#       SPACECRAFT: the spacecraft name from the db
+#       PRODUCT: the product name from the db
+
+
+##########################
+# MANUAL
+#
+# Loops over the configuration file and if the DB does not have the mission,
+# satellite, instrument entries present they are added, skipped otherwise.
+# The product and process entries must be unique and not present.
+#
+# THERE IS CURRENTLY NO UPDATE IN THE DB BASED ON THIS CONFIG SCRIPT
+
+
+##################
+# Required elements
+#
+# [mission]  <- once and only once with
+#   rootdir  (string)
+#   mission_name  (string)
+#   incoming_dir  (string)
+# [satellite] <- once and only once with
+#   satellite_name  (string)
+# [instrument] <- once and only once with
+#   instrument_name  (string)
+##### products and inspector are defined together since they are a one-to-one
+# [product] <- multiple entries each starting with "product" then a unique identifer
+#   product_name  (string)
+#   relative_path  (string)
+#   level  (float)
+#   format  (string)
+#   product_description (string)
+#   inspector_filename (string)
+#   inspector_relative_path (string)
+#   inspector_description (string)
+#   inspector_version (version e.g. 1.0.0)
+#   inspector_output_interface (integer)
+#   inspector_active (Boolean e.g. True or 1 or False or 0)
+#   inspector_date_written (date e.g. 2013-07-12)
+#   inspector_newest_version  (Boolean e.g. True or 1 or False or 0)
+#   inspector_arguments (string)
+#### processes and codes operate on the names of the products, they can be in
+#### this config file or already in the db codes are one-to-one with processes
+# [process] <- multiple entries each starting with "process" then a unique identifer
+#   process_name (string)
+#   output_product (string)  - identifer from section heading OR product_name from db
+#   output_timebase  (string, FILE/DAILY/WEEKLY/MONTHLY/YEARLY)
+#   extra_params (string)
+## A collection of input names entered as such
+## the required portion is "optional_input" or "required_input" then some
+## unique identifer on the end
+## These can be section header identifier OR product_name from db
+## (Tries to match section header first)
+#   optional_input1  (string) name of product - identifer from section heading
+#   optional_input2  (string) name of product - identifer from section heading
+#   optional_input3  (string) name of product - identifer from section heading
+#   required_input1  (string) name of product - identifer from section heading
+#   required_input2  (string) name of product - identifer from section heading
+#   required_input3  (string) name of product - identifer from section heading
+## code is entered as part of process
+#   code_filename (string)
+#   code_relative_path (string)
+#   code_start_date (date, 2000-01-01)
+#   code_stop_date  (date, 2050-12-31)
+#   code_description (string)
+#   code_version  (version e.g. 1.0.0)
+#   code_output_interface  (integer)
+#   code_active (Boolean e.g. True or 1 or False or 0)
+#   code_date_written   (date, 2050-12-31)
+#   code_newest_version (Boolean e.g. True or 1 or False or 0)
+#   code_arguments (string)
+
+[mission]
+mission_name = no_inputs
+rootdir = root
+incoming_dir = dbp_incoming
+codedir = dbp_codes
+inspectordir = dbp_codes/inspectors
+errordir =
+
+[satellite]
+satellite_name = {MISSION}
+
+[instrument]
+instrument_name = inputless_inst
+
+[product_test_inputless]
+product_name = test_inputless
+relative_path = data
+level = 1.0
+format = inputless_{Y}{m}{d}_v{VERSION}.txt
+product_description = Simple text file
+inspector_filename = inputless_inspector.py
+inspector_relative_path =
+inspector_description = Inspect for inputless file
+inspector_version = 1.0.0
+inspector_output_interface = 1
+inspector_active = True
+inspector_date_written = 2020-09-04
+inspector_newest_version = True
+inspector_arguments =
+
+[process_inputless]
+process_name = inputless
+output_product = product_test_inputless
+output_timebase = DAILY
+extra_params =
+code_filename = inputless_v{CODEVERSION}.py
+code_relative_path = scripts/inputless_v{CODEVERSION}
+code_start_date = 2009-09-01
+code_stop_date = 2050-01-01
+code_description = Make a stupid text file based on name
+code_version = 1.0.0
+code_output_interface = 1
+code_active = True
+code_date_written = 2020-09-04
+code_newest_version = True
+code_arguments =
+code_cpu = 1
+code_ram = 1

--- a/developer/functionals/no_inputs/root/dbp_codes/inspectors/inputless_inspector.py
+++ b/developer/functionals/no_inputs/root/dbp_codes/inspectors/inputless_inspector.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+"""Inspector for "inputless" simple files"""
+import datetime
+import re
+
+from dbprocessing import inspector
+from dbprocessing import Version
+
+class Inspector(inspector.inspector):
+    code_name = "inputless_inspector.py"
+
+    def inspect(self, kwargs):
+        #Check for reasonable inputs
+        m = re.match(r'^.*(\d{8})_v((?:\d+\.){3})txt$',
+                     self.basename)
+        if m is None:
+            return None
+        datestr, ver = m.group(1, 2)
+        ver = ver[:-1]
+        utc_dt = datetime.datetime.strptime(datestr, "%Y%m%d")
+        self.diskfile.params['utc_file_date'] = utc_dt.date()
+        self.diskfile.params['version'] = Version.Version.fromString(ver)
+        self.diskfile.params['utc_start_time'] = utc_dt
+        self.diskfile.params['utc_stop_time'] = utc_dt.replace(
+            hour=23, minute=59, second=59, microsecond=59)
+        return True

--- a/developer/functionals/no_inputs/root/dbp_codes/scripts/inputless_v1.0.0/inputless_v1.0.0.py
+++ b/developer/functionals/no_inputs/root/dbp_codes/scripts/inputless_v1.0.0/inputless_v1.0.0.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+"""Create a file based on the date implicit in its filename."""
+
+import os.path
+import re
+import sys
+
+assert len(sys.argv) == 2
+outfile = sys.argv[1]
+datestr, ver = re.match(r'^.*(\d{8})_v((?:\d+\.){3})txt$',
+                        os.path.basename(outfile)).group(1, 2)
+ver = ver[:-1] # Cut trailing .
+with open(outfile, 'w') as f:
+    f.write('Date: {} Version: {}\n'.format(datestr, ver))

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -109,7 +109,7 @@ triggering such processing.
 
 .. option:: process_id
 
-   Process ID of process to run.
+   Process ID or process name of process to run.
 
 .. option:: -d, --dryrun
 

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -138,6 +138,12 @@ such processing.)
 
    Number of processes to run in parallel
 
+.. option:: -i, --ingest
+
+   Ingest created files into the database. This will also add them to the
+   process queue, to be built into further products by ProcessQueue -p.
+   (Default: create in current directory and do not add to database.)
+
 .. option:: -u, --update
 
    Only run files that have not yet been created or with updated codes.

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -95,16 +95,17 @@ Show files in database but not on disk. Additionally, this can remove files from
 .. option:: --startID The File id to start on
 .. option:: -v, --verbose Print out each file as it is checked
 
-DBRunner.py:
-------------
+DBRunner.py
+-----------
 .. program:: DBRunner.py
 
 Used to demo run codes for certain dates out of the database. This primarily used in testing can also be used to reprocess files as needed
 
 As is typical, processes for which there are no input files for a date will
 not be run. However, if a process has no input *products*, dates specified
-will always run (unlike in ProcessQueue, which has no way of triggering
-such processing.)
+will be run, depending on the values of :option:`--force` and
+:option:`--update`. This is unlike `ProcessQueue.py`_, which has no way of
+triggering such processing.
 
 .. option:: process_id
 
@@ -275,8 +276,8 @@ Prints the process queue.
 .. option:: -o, --output The name of the file to output to(if blank, print to stdout)
 .. option:: --html Output in HTML
 
-ProcessQueue.py:
-----------------
+ProcessQueue.py
+---------------
 .. program:: ProcessQueue
 
 The main thing

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -101,6 +101,11 @@ DBRunner.py:
 
 Used to demo run codes for certain dates out of the database. This primarily used in testing can also be used to reprocess files as needed
 
+As is typical, processes for which there are no input files for a date will
+not be run. However, if a process has no input *products*, dates specified
+will always run (unlike in ProcessQueue, which has no way of triggering
+such processing.)
+
 .. option:: filename The filename to save the config
 .. option:: -d, --dryrun Only print what would be done
 .. option:: -m <dbname>, --mission <dbname> Selected mission database

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -97,7 +97,7 @@ Show files in database but not on disk. Additionally, this can remove files from
 
 DBRunner.py:
 ------------
-.. program:: DBRunner
+.. program:: DBRunner.py
 
 Used to demo run codes for certain dates out of the database. This primarily used in testing can also be used to reprocess files as needed
 
@@ -106,14 +106,48 @@ not be run. However, if a process has no input *products*, dates specified
 will always run (unlike in ProcessQueue, which has no way of triggering
 such processing.)
 
-.. option:: filename The filename to save the config
-.. option:: -d, --dryrun Only print what would be done
-.. option:: -m <dbname>, --mission <dbname> Selected mission database
-.. option:: --echo Start sqlalchemy with echo in place for debugging
-.. option:: -s <date>, --startDate <date> Date to start search (e.g. 2012-10-02 or 20121002)
-.. option:: -e <date>, --endDate <date> Date to end search (e.g. 2012-10-25 or 20121025)
-.. option:: --nooptional Do not include optional inputs
-.. option:: -n, --num-proc Number of processes to run in parallel
+.. option:: process_id
+
+   Process ID of process to run.
+
+.. option:: -d, --dryrun
+
+   Only print what would be done (not currently working).
+
+.. option:: -m <dbname>, --mission <dbname>
+
+   Selected mission database
+
+.. option:: --echo
+
+   Start sqlalchemy with echo in place for debugging
+
+.. option:: -s <date>, --startDate <date>
+
+   Date to start search (e.g. 2012-10-02 or 20121002)
+
+.. option:: -e <date>, --endDate <date>
+
+   Date to end search (e.g. 2012-10-25 or 20121025)
+
+.. option:: --nooptional
+
+   Do not include optional inputs
+
+.. option:: -n, --num-proc
+
+   Number of processes to run in parallel
+
+.. option:: -u, --update
+
+   Only run files that have not yet been created or with updated codes.
+   Mutually exclusive with --force, -v. (Default: run all.)
+
+.. option:: --force {0,1,2}
+
+   Run all files in given date range and always increment version
+   (0: interface; 1: quality; 2: revision). Mutually exclusive with -u, -v.
+   (Default: run all but do not increment version.)
 
 deleteAllDBFiles.py:
 --------------------

--- a/scripts/DBRunner.py
+++ b/scripts/DBRunner.py
@@ -68,8 +68,8 @@ def parse_args(argv=None):
         help="Do not include optional inputs") # logic is backwards
     parser.add_argument("-n", "--num-proc", dest="numproc", type=int, default=1,
                         help="Number of processes to run in parallel")
-    parser.add_argument('process_id', action='store', type=int,
-                        help="Process ID of process to run")
+    parser.add_argument('process_id', action='store',
+                        help="Process ID or name of process to run")
 
     options = parser.parse_args(argv)
     if options.ingest and options.force is None and not options.update:
@@ -101,8 +101,8 @@ def calc_runme(pq, startDate, endDate, inproc,
         First date to process (inclusive)
     endDate : datetime.datetime
         Last date to process (inclusive)
-    inproc : int
-        Process ID to run
+    inproc : int or str
+        Process ID or name to run
     version_bump : int
         Which component of version to bump (0-2, 0 for interface).
         Cannot combine with `update`. Default: do not bump version.

--- a/scripts/DBRunner.py
+++ b/scripts/DBRunner.py
@@ -121,10 +121,12 @@ def calc_runme(pq, startDate, endDate, inproc,
              for d in Utils.expandDates(startDate, endDate)]
     print('dates', dates)
 
-    timebase = pq.dbu.getProcessTimebase(inproc)
+    # Get the full Process entry for the process ID
+    inproc = pq.dbu.getEntry('Process', inproc)
+    timebase = pq.dbu.getProcessTimebase(inproc.process_id)
 
     # get the input products for a process
-    products = pq.dbu.getInputProductID(inproc)
+    products = pq.dbu.getInputProductID(inproc.process_id)
     print('products', products)
 
     runme = []
@@ -145,14 +147,15 @@ def calc_runme(pq, startDate, endDate, inproc,
             input_files.extend([v.file_id for v in files])
         if not input_files:
             print("{3} ({0}) {1} on {2}".format(
-                inproc, pq.dbu.getEntry('Process', inproc).process_name,
+                inproc.process_id, inproc.process_name,
                 d.isoformat(),
                 "No files to run for" if products
                 else "No input product, always check"))
             if products: # Skip the run.
                 continue
         r = runMe.runMe(
-            pq.dbu, d, inproc, input_files, pq, version_bump=version_bump,
+            pq.dbu, d, inproc.process_id, input_files, pq,
+            version_bump=version_bump,
             # "force" flag means "force even if version conflict"; no
             # version conflicts if bumping version or only running out-of-date
             force=(version_bump is None and not update))

--- a/scripts/DBRunner.py
+++ b/scripts/DBRunner.py
@@ -60,6 +60,9 @@ def parse_args(argv=None):
     howtorun.add_argument("-v", "--version",  default='1.0.0',
                           help="NOTIMPLEMENTED set output version."
                           " Mutually exclusive with --force, -u.")
+    parser.add_argument("-i", "--ingest", action="store_true", default=False,
+                        help="Ingest the created files. Requires -u or --force."
+                        " (Default: create file in current directory.)")
     parser.add_argument(
         "--nooptional", dest="optional", action="store_false", default=True,
         help="Do not include optional inputs") # logic is backwards
@@ -69,6 +72,8 @@ def parse_args(argv=None):
                         help="Process ID of process to run")
 
     options = parser.parse_args(argv)
+    if options.ingest and options.force is None and not options.update:
+        parser.error("argument -i/--ingest: requires --force or --update")
 
     if options.startDate is not None:
         options.startDate = dup.parse(options.startDate)
@@ -156,6 +161,8 @@ def calc_runme(pq, startDate, endDate, inproc,
 
 if __name__ == "__main__":
     options = parse_args()
+    if options.ingest:
+        raise NotImplementedError('Ingest not functional yet.')
     inproc = options.process_id
     pq = dbprocessing.ProcessQueue(options.mission, dryrun=options.dryrun, echo=options.echo)
     runme = calc_runme(pq, options.startDate, options.endDate, inproc,

--- a/scripts/DBRunner.py
+++ b/scripts/DBRunner.py
@@ -161,11 +161,10 @@ def calc_runme(pq, startDate, endDate, inproc,
 
 if __name__ == "__main__":
     options = parse_args()
-    if options.ingest:
-        raise NotImplementedError('Ingest not functional yet.')
     inproc = options.process_id
     pq = dbprocessing.ProcessQueue(options.mission, dryrun=options.dryrun, echo=options.echo)
     runme = calc_runme(pq, options.startDate, options.endDate, inproc,
                        version_bump=options.force, update=options.update)
-    runMe.runner(runme, pq.dbu, MAX_PROC=options.numproc, rundir='.')
+    runMe.runner(runme, pq.dbu, MAX_PROC=options.numproc,
+                 rundir=None if options.ingest else '.')
                 

--- a/scripts/DBRunner.py
+++ b/scripts/DBRunner.py
@@ -148,14 +148,18 @@ def calc_runme(pq, startDate, endDate, inproc,
                 inproc, pq.dbu.getEntry('Process', inproc).process_name,
                 d.isoformat(),
                 "No files to run for" if products
-                else "No input product, always run"))
+                else "No input product, always check"))
             if products: # Skip the run.
                 continue
-        runme.append(runMe.runMe(
+        r = runMe.runMe(
             pq.dbu, d, inproc, input_files, pq, version_bump=version_bump,
             # "force" flag means "force even if version conflict"; no
             # version conflicts if bumping version or only running out-of-date
-            force=(version_bump is None and not update)))
+            force=(version_bump is None and not update))
+        if r.ableToRun or version_bump is not None or not update:
+            runme.append(r)
+        else:
+            print("Up to date, not running.")
     return runme
 
 

--- a/scripts/DBRunner.py
+++ b/scripts/DBRunner.py
@@ -121,11 +121,14 @@ def calc_runme(pq, startDate, endDate, inproc):
 
             input_files.extend([v.file_id for v in files])
         if not input_files:
-            print("No files to run for process ({0}) {1} on {2}".format(inproc,
-                                                                      pq.dbu.getEntry('Process', inproc).process_name,
-                                                                      d.isoformat()))
-        else:
-            runme.append(runMe.runMe(pq.dbu, d, inproc, input_files, pq, force=True))
+            print("{3} ({0}) {1} on {2}".format(
+                inproc, pq.dbu.getEntry('Process', inproc).process_name,
+                d.isoformat(),
+                "No files to run for" if products
+                else "No input product, always run"))
+            if products: # Skip the run.
+                continue
+        runme.append(runMe.runMe(pq.dbu, d, inproc, input_files, pq, force=True))
     return runme
 
 

--- a/scripts/DBRunner.py
+++ b/scripts/DBRunner.py
@@ -34,17 +34,17 @@ def parse_args(argv=None):
         Arguments from command line, from flags and non-flag arguments.
     """
     parser = argparse.ArgumentParser()
-    parser.add_argument("-d", "--dryrun", dest="dryrun", action="store_true",
+    parser.add_argument("-d", "--dryrun", action="store_true",
                         help="dryrun, only print what would be done", default=False)
-    parser.add_argument("-v", "--version", dest="version", type=str,
+    parser.add_argument("-v", "--version",
                         help="NOTIMPLEMENTED set output version", default='1.0.0')
-    parser.add_argument("-m", "--mission", dest="mission",
+    parser.add_argument("-m", "--mission",
                         help="selected mission database", required=True)
-    parser.add_argument("--echo", dest="echo", action="store_true",
+    parser.add_argument("--echo", action="store_true",
                         help="Start sqlalchemy with echo in place for debugging", default=False)
-    parser.add_argument("-s", "--startDate", dest="startDate", type=str,
+    parser.add_argument("-s", "--startDate",
                         help="Date to start search (e.g. 2012-10-02 or 20121002)", default=None)
-    parser.add_argument("-e", "--endDate", dest="endDate", type=str,
+    parser.add_argument("-e", "--endDate",
                         help="Date to end search (e.g. 2012-10-25 or 20121025)", default=None)
     parser.add_argument("--nooptional", dest="optional", action="store_false",
                         help="Do not include optional inputs", default=True) # logic is backwards

--- a/scripts/DBRunner.py
+++ b/scripts/DBRunner.py
@@ -34,22 +34,26 @@ def parse_args(argv=None):
         Arguments from command line, from flags and non-flag arguments.
     """
     parser = argparse.ArgumentParser()
-    parser.add_argument("-d", "--dryrun", action="store_true",
-                        help="dryrun, only print what would be done", default=False)
-    parser.add_argument("-v", "--version",
-                        help="NOTIMPLEMENTED set output version", default='1.0.0')
-    parser.add_argument("-m", "--mission",
-                        help="selected mission database", required=True)
-    parser.add_argument("--echo", action="store_true",
-                        help="Start sqlalchemy with echo in place for debugging", default=False)
-    parser.add_argument("-s", "--startDate",
-                        help="Date to start search (e.g. 2012-10-02 or 20121002)", default=None)
-    parser.add_argument("-e", "--endDate",
-                        help="Date to end search (e.g. 2012-10-25 or 20121025)", default=None)
-    parser.add_argument("--nooptional", dest="optional", action="store_false",
-                        help="Do not include optional inputs", default=True) # logic is backwards
-    parser.add_argument("-n", "--num-proc", dest="numproc", type=int,
-                        help="Number of processes to run in parallel", default=1)
+    parser.add_argument("-d", "--dryrun", action="store_true", default=False,
+                        help="dryrun, only print what would be done")
+    parser.add_argument("-v", "--version",  default='1.0.0',
+                        help="NOTIMPLEMENTED set output version")
+    parser.add_argument("-m", "--mission", required=True,
+                        help="selected mission database")
+    parser.add_argument("--echo", action="store_true", default=False,
+                        help="Start sqlalchemy with echo in place for"
+                        " debugging")
+    parser.add_argument("-s", "--startDate", default=None,
+                        help="Date to start search (e.g. 2012-10-02 or"
+                        " 20121002)")
+    parser.add_argument("-e", "--endDate", default=None,
+                        help="Date to end search (e.g. 2012-10-25 or"
+                        " 20121025)")
+    parser.add_argument(
+        "--nooptional", dest="optional", action="store_false", default=True,
+        help="Do not include optional inputs") # logic is backwards
+    parser.add_argument("-n", "--num-proc", dest="numproc", type=int, default=1,
+                        help="Number of processes to run in parallel")
     parser.add_argument('process_id', action='store', type=int,
                         help="Process ID of process to run")
 

--- a/unit_tests/test_DBRunner.py
+++ b/unit_tests/test_DBRunner.py
@@ -24,7 +24,7 @@ class DBRunnerTests(unittest.TestCase):
         options = DBRunner.parse_args([
             '-m', 'foo.sqlite', '-s', '20180101', '5'])
         self.assertEqual(
-            5, options.process_id)
+            '5', options.process_id)
         self.assertEqual(
             'foo.sqlite', options.mission)
         self.assertEqual(
@@ -56,6 +56,10 @@ class DBRunnerTests(unittest.TestCase):
         self.assertFalse(options.update)
         self.assertEqual(1, options.force)
         self.assertTrue(options.ingest)
+        options = DBRunner.parse_args([
+            '-m', 'foo.sqlite', '-s', '20180101', 'foo'])
+        self.assertEqual(
+            'foo' , options.process_id)
 
     def test_parse_dbrunner_args_bad(self):
         """Parse the command line arguments with errors"""

--- a/unit_tests/test_DBRunner.py
+++ b/unit_tests/test_DBRunner.py
@@ -21,10 +21,10 @@ class DBRunnerTests(unittest.TestCase):
 
     def test_parse_dbrunner_args(self):
         """Parse the command line arguments"""
-        args, options = DBRunner.parse_args([
+        options = DBRunner.parse_args([
             '-m', 'foo.sqlite', '-s', '20180101', '5'])
         self.assertEqual(
-            ['5'], args)
+            5, options.process_id)
         self.assertEqual(
             'foo.sqlite', options.mission)
         self.assertEqual(

--- a/unit_tests/test_DBRunner.py
+++ b/unit_tests/test_DBRunner.py
@@ -157,7 +157,6 @@ class DBRunnerCalcRunmeTests(unittest.TestCase, dbp_testing.AddtoDBMixin):
 
     def test_runme_list_options(self):
         """List of processes to run, no input, various forcing"""
-        print('foo')
         prodid = self.addProduct(
             product_name='triggered_output',
             instrument_id=1,

--- a/unit_tests/test_DBRunner.py
+++ b/unit_tests/test_DBRunner.py
@@ -87,7 +87,7 @@ class DBRunnerTests(unittest.TestCase):
                 sys.stderr.close()
                 sys.stderr = oldstderr
             self.assertEqual(
-                '{}: error: {}'.format(os.path.basename(__file__), msg), err)
+                '{}: error: {}'.format(os.path.basename(sys.argv[0]), msg), err)
 
 
 class DBRunnerCalcRunmeTests(unittest.TestCase, dbp_testing.AddtoDBMixin):

--- a/unit_tests/test_DBRunner.py
+++ b/unit_tests/test_DBRunner.py
@@ -36,6 +36,7 @@ class DBRunnerTests(unittest.TestCase):
         self.assertFalse(options.echo)
         self.assertEqual(1, options.numproc)
         self.assertFalse(options.update)
+        self.assertFalse(options.ingest)
         self.assertTrue(options.force is None)
 
     def test_parse_dbrunner_args_other(self):
@@ -46,16 +47,27 @@ class DBRunnerTests(unittest.TestCase):
         options = DBRunner.parse_args([
             '-m', 'foo.sqlite', '-s', '20180101', '5', '-u'])
         self.assertTrue(options.update)
+        options = DBRunner.parse_args([
+            '-m', 'foo.sqlite', '-s', '20180101', '5', '-u', '-i'])
+        self.assertTrue(options.update)
+        self.assertTrue(options.ingest)
+        options = DBRunner.parse_args([
+            '-m', 'foo.sqlite', '-s', '20180101', '5', '--force', '1', '-i'])
+        self.assertFalse(options.update)
+        self.assertEqual(1, options.force)
+        self.assertTrue(options.ingest)
 
     def test_parse_dbrunner_args_bad(self):
         """Parse the command line arguments with errors"""
         arglist = [
             ['--force', '6'],
             ['--force', '0', '-u'],
+            ['-i'],
             ]
         msgs = [
             'argument --force: invalid choice: 6 (choose from 0, 1, 2)',
             'argument -u/--update: not allowed with argument --force',
+            'argument -i/--ingest: requires --force or --update',
             ]
         oldstderr = sys.stderr
         for args, msg in zip(arglist, msgs):

--- a/unit_tests/test_DBRunner.py
+++ b/unit_tests/test_DBRunner.py
@@ -33,9 +33,45 @@ class DBRunnerTests(unittest.TestCase):
         self.assertTrue(
             datetime.datetime.now() - options.endDate
             < datetime.timedelta(seconds=10))
-        self.assertEqual(
-            False, options.echo)
+        self.assertFalse(options.echo)
         self.assertEqual(1, options.numproc)
+        self.assertFalse(options.update)
+        self.assertTrue(options.force is None)
+
+    def test_parse_dbrunner_args_other(self):
+        """Parse the command line with other options"""
+        options = DBRunner.parse_args([
+            '-m', 'foo.sqlite', '-s', '20180101', '5', '--force', '0'])
+        self.assertEqual(0, options.force)
+        options = DBRunner.parse_args([
+            '-m', 'foo.sqlite', '-s', '20180101', '5', '-u'])
+        self.assertTrue(options.update)
+
+    def test_parse_dbrunner_args_bad(self):
+        """Parse the command line arguments with errors"""
+        arglist = [
+            ['--force', '6'],
+            ['--force', '0', '-u'],
+            ]
+        msgs = [
+            'argument --force: invalid choice: 6 (choose from 0, 1, 2)',
+            'argument -u/--update: not allowed with argument --force',
+            ]
+        oldstderr = sys.stderr
+        for args, msg in zip(arglist, msgs):
+            sys.stderr = (io.BytesIO if str is bytes else io.StringIO)()
+            try:
+                with self.assertRaises(SystemExit) as cm:
+                    DBRunner.parse_args(
+                        ['-m', 'foo.sqlite', '-s', '20180101', '5'] + args)
+                # Cut off all the usage information, just get the error.
+                # (ends with blank line, so skip that).
+                err = sys.stderr.getvalue().split('\n')[-2]
+            finally:
+                sys.stderr.close()
+                sys.stderr = oldstderr
+            self.assertEqual(
+                '{}: error: {}'.format(os.path.basename(__file__), msg), err)
 
 
 class DBRunnerCalcRunmeTests(unittest.TestCase, dbp_testing.AddtoDBMixin):
@@ -102,6 +138,80 @@ class DBRunnerCalcRunmeTests(unittest.TestCase, dbp_testing.AddtoDBMixin):
         rm = runme[0]
         self.assertEqual('/n/space_data/cda/rbsp/scripts/junk.py', rm.codepath)
         self.assertEqual('trigger_20100101_v1.0.0.out', rm.filename)
+
+    def test_runme_list_options(self):
+        """List of processes to run, no input, various forcing"""
+        print('foo')
+        prodid = self.addProduct(
+            product_name='triggered_output',
+            instrument_id=1,
+            format='trigger_{Y}{m}{d}_v{VERSION}.out',
+            level=2)
+        procid, codeid = self.addProcess('no_input', output_product_id=prodid)
+        with self.assertRaises(ValueError): # --force with -u, essentially
+            runme = DBRunner.calc_runme(self.pq, datetime.datetime(2010, 1, 1),
+                                        datetime.datetime(2010, 1, 1), procid,
+                                        version_bump=1, update=True)
+        # Most of this is really a test of runMe, and it's tested there,
+        # but this makes sure that the chosen arguments to runMe have the
+        # desired result.
+        # No output files yet, so all ways of running should be the same.
+        for vb, u in [(None, False), (1, False), (None, True)]:
+            runme = DBRunner.calc_runme(self.pq, datetime.datetime(2010, 1, 1),
+                                        datetime.datetime(2010, 1, 1), procid,
+                                        version_bump=vb, update=u)
+            self.assertEqual(1, len(runme))
+            rm = runme[0]
+            self.assertTrue(rm.ableToRun)
+            self.assertEqual('trigger_20100101_v1.0.0.out', rm.filename)
+        # Make an existing file
+        fid = self.addFile('trigger_20100101_v1.0.0.out', prodid)
+        self.dbu.addFilecodelink(fid, codeid)
+        # Now only version bump or no-update should make output
+        for vb, u, v in [(None, False, '1.0.0'), # default
+                         (1, False, '1.1.0'), # --force 1
+                         (2, False, '1.0.1'), # --force 2
+                         (None, True, None)]: # -u
+            runme = DBRunner.calc_runme(self.pq, datetime.datetime(2010, 1, 1),
+                                        datetime.datetime(2010, 1, 1), procid,
+                                        version_bump=vb, update=u)
+            self.assertEqual(1, len(runme))
+            rm = runme[0]
+            if v is None:
+                self.assertFalse(rm.ableToRun)
+            else:
+                self.assertTrue(rm.ableToRun)
+                self.assertEqual('trigger_20100101_v{}.out'.format(v),
+                                 rm.filename)
+        # Update the code
+        oldcode = self.dbu.getEntry('Code', codeid)
+        newcode = self.dbu.Code()
+        for k in dir(newcode):
+            if not k.startswith('_'):
+                setattr(newcode, k, getattr(oldcode, k))
+        newcode.code_id = None
+        newcode.filename = 'new_junk.py'
+        newcode.quality_version = 1
+        self.dbu.session.add(newcode)
+        self.dbu.commitDB()
+        # Old code no longer active
+        self.dbu.updateCodeNewestVersion(codeid)
+        # Now all should make output, but default doesn't update version
+        for vb, u, v in [(None, False, '1.0.0'), # default
+                         (1, False, '1.1.0'), # --force 1
+                         (2, False, '1.0.1'), # --force 2
+                         (None, True, '1.1.0')]: # -u
+            runme = DBRunner.calc_runme(self.pq, datetime.datetime(2010, 1, 1),
+                                        datetime.datetime(2010, 1, 1), procid,
+                                        version_bump=vb, update=u)
+            self.assertEqual(1, len(runme))
+            rm = runme[0]
+            if v is None:
+                self.assertFalse(rm.ableToRun)
+            else:
+                self.assertTrue(rm.ableToRun)
+                self.assertEqual('trigger_20100101_v{}.out'.format(v),
+                                 rm.filename)
 
 
 if __name__ == "__main__":

--- a/unit_tests/test_DBRunner.py
+++ b/unit_tests/test_DBRunner.py
@@ -187,14 +187,15 @@ class DBRunnerCalcRunmeTests(unittest.TestCase, dbp_testing.AddtoDBMixin):
             runme = DBRunner.calc_runme(self.pq, datetime.datetime(2010, 1, 1),
                                         datetime.datetime(2010, 1, 1), procid,
                                         version_bump=vb, update=u)
+            # -u can't make output
+            if v is None:
+                self.assertEqual(0, len(runme))
+                continue
             self.assertEqual(1, len(runme))
             rm = runme[0]
-            if v is None:
-                self.assertFalse(rm.ableToRun)
-            else:
-                self.assertTrue(rm.ableToRun)
-                self.assertEqual('trigger_20100101_v{}.out'.format(v),
-                                 rm.filename)
+            self.assertTrue(rm.ableToRun)
+            self.assertEqual('trigger_20100101_v{}.out'.format(v),
+                             rm.filename)
         # Update the code
         oldcode = self.dbu.getEntry('Code', codeid)
         newcode = self.dbu.Code()

--- a/unit_tests/test_runMe.py
+++ b/unit_tests/test_runMe.py
@@ -284,7 +284,12 @@ class RunMeCmdArgTests(unittest.TestCase, dbp_testing.AddtoDBMixin):
         rm = dbprocessing.runMe.runMe(
             self.dbu, datetime.date(2013, 9, 21), procid,
             [], None, version_bump=None)
-        # Make sure this is runnable
+        # Should not be runnable, because no change (would conflict)
+        self.assertFalse(rm.ableToRun)
+        # But if force, that marks runnable even with conflict
+        rm = dbprocessing.runMe.runMe(
+            self.dbu, datetime.date(2013, 9, 21), procid,
+            [], None, version_bump=None, force=True)
         self.assertTrue(rm.ableToRun)
         # And now the command line itself
         rm.make_command_line()


### PR DESCRIPTION
NOTE: This PR conflicts with #24, in that it includes everything from #24. Either this can be merged and #24 closed, or when #24 is merged I'll rebase this one to the new master.

This PR enhances DBRunner in several ways:

- Allows execution of processes with no inputs
- Adds option to ingest the created files
- Adds option to bump the version to avoid DB conflicts, or only produce files which are out of date

This closes #9 by implementing the checklist/design there.

I had #24 open to get the testing-related changes out faster and hopefully have them reviewed before I did the functionality here. So if someone has time to review this one, it will get everything...if only a little time, then #24 can come first (and this one will have to wait for the rebase.)

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] Major new functionality has appropriate Sphinx documentation
- [x] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature (Ooops, we don't have a CHANGELOG set up yet, should probably do so and/or edit template)
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked in the description (e.g. `See issue #` or `Closes #`)
