### PR TITLE
Run unit tests in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
            at: ~/.local
        - run:
            command: |
-             python unit_tests/test_all.py
+             python unit_tests/test_all.py -v
   createpostgres:
     docker:
       - image: circleci/python:2.7.18

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,17 +21,15 @@ jobs:
       PGHOST: localhost
     steps:
        - checkout
-       - run: sudo chown -R circleci:circleci /usr/local/bin
-       - run: sudo chown -R circleci:circleci /usr/local/lib/python2.7/site-packages
        - run: sudo apt-get install vim
        - run: 
            command: |
              sudo apt install -y postgresql-client
              createdb -h localhost sndd -O root
-             pip install sqlalchemy
-             pip install python-dateutil
-             pip install psycopg2
-             python setup.py install
+             pip install --user sqlalchemy
+             pip install --user python-dateutil
+             pip install --user psycopg2
+             python setup.py install --user
              python scripts/CreateDBsabrs.py
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,7 @@ jobs:
     docker:
       - image: circleci/python:2.7.18
         environment:
-          PIPENV_VENV_IN_PROJECT: true
           DATABASE_URL: postgresql://root@localhost/circle_test?sslmode=disable
-    
       - image: circleci/postgres:9.6.2-alpine
     environment:
       POSTGRES_USER: root

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,30 @@ jobs:
   build:
     docker:
       - image: circleci/python:2.7.18
+    steps:
+       - checkout
+       - run:
+           command: |
+             pip install --user sqlalchemy
+             pip install --user python-dateutil
+             python setup.py install --user
+       - persist_to_workspace:
+           root: ~/.local
+           paths:
+             - lib # Save installed Python libraries (including dbp itself)
+  unittest:
+    docker:
+      - image: circleci/python:2.7.18
+    steps:
+       - checkout
+       - attach_workspace:
+           at: ~/.local
+       - run:
+           command: |
+             python unit_tests/test_all.py
+  createpostgres:
+    docker:
+      - image: circleci/python:2.7.18
         environment:
           DATABASE_URL: postgresql://root@localhost/circle_test?sslmode=disable
       - image: circleci/postgres:9.6.2-alpine
@@ -19,17 +43,22 @@ jobs:
       PGHOST: localhost
     steps:
        - checkout
-       - run: 
+       - attach_workspace:
+           at: ~/.local
+       - run:
            command: |
              sudo apt install -y postgresql-client
              createdb -h localhost sndd -O root
-             pip install --user sqlalchemy
-             pip install --user python-dateutil
              pip install --user psycopg2
-             python setup.py install --user
              python scripts/CreateDBsabrs.py
 
 workflows:
   main:
     jobs:
      - build
+     - unittest:
+         requires:
+           - build
+     - createpostgres:
+         requires:
+           - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,6 @@ jobs:
       PGHOST: localhost
     steps:
        - checkout
-       - run: sudo apt-get install vim
        - run: 
            command: |
              sudo apt install -y postgresql-client

--- a/docs/developer/github.rst
+++ b/docs/developer/github.rst
@@ -3,7 +3,7 @@ Github integration
 ******************
 
 There are several files in the repository that serve to manage the interaction
-between github and the repository, and other settings in github that are
+between GitHub and the repository, and other settings in GitHub that are
 relevant. Generally administrators manage thes settings, but anybody can
 submit a pull request that changes the files managing this interaction.
 
@@ -18,7 +18,8 @@ Several documentation files are also rendered by Github. See
 Issue and Pull Request Templates
 ================================
 These files are in the ``.github`` directory of the repository, and documented
-`here <https://docs.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates>`_
+`at GitHub <https://docs.github.com/en/github/building-a-strong-community/
+about-issue-and-pull-request-templates>`_.
 
 Settings
 ========
@@ -32,3 +33,45 @@ This is stored on a separate branch; `this page <https://docs.github.com/
 en/github/working-with-github-pages/
 configuring-a-publishing-source-for-your-github-pages-site>`_ describes
 how it is rendered.
+
+CircleCI
+========
+Continuous integration is managed through `CircleCI <https://circleci.com/>`_.
+
+Some project settings:
+
+"Only build pull requests" is on; we will not build all branches.
+
+CircleCI refers to a PR that is relative to a fork as a "forked PR". Because
+this the preferred means of submitting a PR, "Build forked pull requests"
+is on. (The PR itself must actually be submitted to the dbprocessing
+repository).
+
+We require status checks to pass before merging to master; in the GitHub
+branch settings, this takes the form of a branch protection rule that requires
+the circleci jobs to succeed on the PR. `This document
+<https://support.circleci.com/hc/en-us/articles/
+360004346254-Workflow-status-checks-never-completes-because-
+of-ci-circleci-Waiting-for-status-to-be-reported>`_ is somewhat ambiguous,
+but what it appears to mean is that the top-level circleci check should not
+be selected (individual jobs should.). All jobs are selected.
+
+The GitHub checks are set up as described `in the CircleCI docs
+<https://circleci.com/docs/2.0/enable-checks/>`_. This involves
+enabling GitHub checks on the dbprocessing repository (which
+ultimately redirects to a GitHub setting) and then enabling "GitHub
+Status Updates" in the CircleCI advanced project settings.
+
+The "webhooks" repository setting on GitHub controls the triggering of
+CircleCI; this is set to "Let me select individual events" and we have
+just "Pull requests", "Pushes" and "Releases" selected. (This was the
+default setup; normally only PRs matter, as we don't do pushes without
+PR, and we don't do CircleCI processing of releases.) This is also
+where a hook can be re-delivered to CircleCI (triggering processing
+again) if the build never happened on CircleCI (the build can also be
+restarted on CircleCI if it has already run.)
+
+For ssh access to the CircleCI build environment, click "Project
+Settings" in the dbprocessing project on CircleCI, then "SSH Keys" and
+add a key there. (This needs to be the private key, so use one just
+for this purpose.)

--- a/scripts/DBRunner.py
+++ b/scripts/DBRunner.py
@@ -8,7 +8,6 @@ import traceback
 import subprocess
 
 import dateutil.parser as dup
-import spacepy.toolbox as tb
 
 from dbprocessing import dbprocessing
 from dbprocessing.runMe import ProcessException


### PR DESCRIPTION
This PR sets up unit testing in CircleCI.

It documents the basic CircleCI/GitHub setup, for configuration which isn't in the .yaml (Closes #16).

It splits the build and the tests into separate jobs: the build which installs most dependencies and dbprocessing itself, the postgres test which installs the necessary postgres tools and creates the postgres db, and the unittest job which runs the unit tests (Closes #15). It uses workspace persistence to carry .local across (which catches all the Python installs, basically.)

It also clears out a few things we aren't currently using:

- It doesn't install vim, since it would need to do that for every job, slowing things down. vim can be installed from the command line after ssh in if something needs to be debugged.
- It removes the environment variable setting for pip virtualenv handling, since we aren't using virtualenv. Might be a nice thing to look into, particularly once caching can be set up.

This doesn't do any caching at this point...I wanted to get the basic setup running. But in the future some level of caching the pip installs might be useful.

Draft for now until I can be sure the tests actually work....

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] (N/A) Major new functionality has appropriate Sphinx documentation
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked in the description (e.g. `See issue #` or `Closes #`)

