### PR TITLE
Speed up getFiles by start/stop time (Closes #23)

### DIFF
--- a/dbprocessing/DButils.py
+++ b/dbprocessing/DButils.py
@@ -1483,6 +1483,19 @@ class DButils(object):
             d1.newest_version = False
 
         self.session.add(d1)
+        if hasattr(self, 'Unixtime'):
+            # Populate file_id, but still allow rollback of file insert
+            self.session.flush()
+            unx0 = datetime.datetime(1970, 1, 1)
+            r = self.Unixtime()
+            r.file_id = d1.file_id
+            r.unix_start = None if utc_start_time is None \
+                           else int((utc_start_time - unx0)\
+                                    .total_seconds()) # Round down
+            r.unix_stop = None if utc_stop_time is None\
+                          else int(math.ceil((utc_stop_time - unx0)\
+                                             .total_seconds())) # Round up
+            self.session.add(r)
         self.commitDB()
         return d1.file_id
 

--- a/dbprocessing/DButils.py
+++ b/dbprocessing/DButils.py
@@ -2662,9 +2662,11 @@ class DButils(object):
             'unixtime', self.metadata,
             sqlalchemy.Column(
                 'file_id', sqlalchemy.Integer,
-                sqlalchemy.ForeignKey('file.file_id'), primary_key=True),
+                sqlalchemy.ForeignKey('file.file_id'),
+                primary_key=True, index=True),
             sqlalchemy.Column('unix_start', sqlalchemy.Integer, index=True),
-            sqlalchemy.Column('unix_stop', sqlalchemy.Integer, index=True)
+            sqlalchemy.Column('unix_stop', sqlalchemy.Integer, index=True),
+            sqlalchemy.CheckConstraint('unix_start <= unix_stop'),
         )
         self.metadata.create_all(tables=[unixtime])
         # Make object for the new table definition (skips existing tables)

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -233,6 +233,26 @@ In a given directory, make symlinks to all the newest versions of files into ano
 
 .. warning:: There's no documentation on the config file
 
+MigrateDB.py
+------------
+.. program:: MigrateDB.py
+
+Migrate a database to the latest structure.
+
+Right now this only adds a Unix time table that stores the UTC start/end
+time as seconds since Unix epoch, but planned to extend to support all
+other database changes to date.
+
+Will display all possible changes and prompt for confirmation.
+
+.. option:: -m <dbname>, --mission <dbname>
+
+   Selected mission database
+
+.. option:: -y, --yes
+
+   Process possible changes without asking for confirmation.
+
 missingFilesByProduct.py:
 -------------------------
 Attempt to reprocess files that are missing, 90% solution, not used much, but did work

--- a/scripts/CreateDB.py
+++ b/scripts/CreateDB.py
@@ -165,6 +165,13 @@ class dbprocessing_db(object):
                      data_table.columns['utc_start_time'],
                      data_table.columns['utc_stop_time'], unique=True)
 
+        data_table = schema.Table('unixtime', metadata,
+                                  schema.Column('file_id', types.Integer,
+                                                schema.ForeignKey('file.file_id'), primary_key=True),
+                                  schema.Column('unix_start', types.Integer, index=True),
+                                  schema.Column('unix_stop', types.Integer, index=True),
+        )
+
         data_table = schema.Table('filefilelink', metadata,
                                   schema.Column('source_file', types.Integer,
                                                 schema.ForeignKey('file.file_id'), nullable=False, index=True),

--- a/scripts/CreateDB.py
+++ b/scripts/CreateDB.py
@@ -167,9 +167,10 @@ class dbprocessing_db(object):
 
         data_table = schema.Table('unixtime', metadata,
                                   schema.Column('file_id', types.Integer,
-                                                schema.ForeignKey('file.file_id'), primary_key=True),
+                                                schema.ForeignKey('file.file_id'), primary_key=True, index=True),
                                   schema.Column('unix_start', types.Integer, index=True),
                                   schema.Column('unix_stop', types.Integer, index=True),
+                                  schema.CheckConstraint('unix_start <= unix_stop'),
         )
 
         data_table = schema.Table('filefilelink', metadata,

--- a/scripts/CreateDBsabrs.py
+++ b/scripts/CreateDBsabrs.py
@@ -174,6 +174,13 @@ class dbprocessing_db(object):
                      data_table.columns['utc_stop_time'], unique=True
 		     )
 
+        data_table = schema.Table('unixtime', metadata,
+                                  schema.Column('file_id', types.Integer,
+                                                schema.ForeignKey('file.file_id'), primary_key=True),
+                                  schema.Column('unix_start', types.Integer, index=True),
+                                  schema.Column('unix_stop', types.Integer, index=True),
+        )
+
         data_table = schema.Table('filefilelink', metadata,
                                   schema.Column('source_file', types.Integer,
                                                 schema.ForeignKey('file.file_id'), nullable=False, index=True),

--- a/scripts/CreateDBsabrs.py
+++ b/scripts/CreateDBsabrs.py
@@ -176,9 +176,10 @@ class dbprocessing_db(object):
 
         data_table = schema.Table('unixtime', metadata,
                                   schema.Column('file_id', types.Integer,
-                                                schema.ForeignKey('file.file_id'), primary_key=True),
+                                                schema.ForeignKey('file.file_id'), primary_key=True, index=True),
                                   schema.Column('unix_start', types.Integer, index=True),
                                   schema.Column('unix_stop', types.Integer, index=True),
+                                  schema.CheckConstraint('unix_start <= unix_stop'),
         )
 
         data_table = schema.Table('filefilelink', metadata,

--- a/scripts/MigrateDB.py
+++ b/scripts/MigrateDB.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+
+"""Migrate a dbprocessing database to latest structure"""
+
+import argparse
+import sys
+
+import dbprocessing.DButils
+
+
+def parse_args(argv=None):
+    """Parse arguments for this script
+
+    Parameters
+    ==========
+    argv : list
+        Argument list, default from sys.argv
+
+    Returns
+    =======
+    options : argparse.Values
+        Arguments from command line, from flags and non-flag arguments.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-m", "--mission", required=True,
+                        help="selected mission database")
+    parser.add_argument("-y", "--yes", action="store_true", dest="always",
+                        default=False,
+                          help="Always update without prompting (Default:"
+                          " ask before proceeding.)")
+    options = parser.parse_args(argv)
+    return vars(options)
+
+
+def check_unix_time(dbu):
+    """Check if database needs a table for Unix time
+
+    Parameters
+    ==========
+    dbu : dbprocessing.DButils.DButils
+        Open DButils instances for the mission to update
+
+    Returns
+    =======
+    bool
+        True if update needed (there is no Unix time table);
+        False otherwise (Unix time table exists)
+    """
+    return not hasattr(dbu, 'Unixtime')
+
+
+def do_unix_time(dbu):
+    """Add Unix time table to database
+
+    Parameters
+    ==========
+    dbu : dbprocessing.DButils.DButils
+        Open DButils instances for the mission to update
+    """
+    dbu.addUnixTimeTable()
+
+
+checkme = [
+    ("Unix time table", check_unix_time, do_unix_time)
+]
+"""List of all possible updates. tuple of name, function to check if needed,
+   function to perform the update. Check functions take the open DBUtils and
+   return True if the update is needed, else False."""
+
+
+def main(mission, always=False):
+    """Update a database
+
+    Opens an existing database and updates the structure as needed.
+
+    Parameters
+    ==========
+    mission : str
+        Path to the mission file
+
+    always : bool
+        Always update without prompt (default False, prompt before changes)
+    """
+    dbu = dbprocessing.DButils.DButils(mission)
+    needed = []
+    """List of (name, function to perform update) for every update needed"""
+    for name, checkfunc, dofunc in checkme:
+        dothis = checkfunc(dbu)
+        print('{}: {}'.format(name, 'PENDING' if dothis else 'up to date'))
+        if dothis:
+            needed.append((name, dofunc))
+    if not needed:
+        print('\nNo updates.')
+        return
+    print('\nWill apply updates: ' + ', '.join([name for name, _ in needed]))
+    if always:
+        print('Proceeding without prompt.')
+    else:
+        try:
+            ans = raw_input('Proceed (y/n)? ')
+        except NameError: #Py3k, no raw_input
+            ans = input('Proceed (y/n)? ')
+        if ans.lower()[0] != 'y':
+            print('Canceling.')
+            return
+        print('Proceeding.')
+    print('\nUpdating.')
+    for name, do_func in needed:
+        sys.stdout.write('{}: '.format(name))
+        sys.stdout.flush()
+        do_func(dbu)
+        print('done.')
+    print('Complete.')
+            
+
+
+if __name__ == "__main__":
+    main(**parse_args())
+

--- a/unit_tests/test_DButils.py
+++ b/unit_tests/test_DButils.py
@@ -602,6 +602,12 @@ class DBUtilsGetTests(TestSetup):
         actual = sorted([v.filename for v in val])
         self.assertEqual(expected, actual)
 
+    def test_getFilesUTCDayUnixTime(self):
+        """getFiles with a single UTC day time, lookup by Unix time"""
+        self.dbu.addUnixTimeTable()
+        # Run all the same checks
+        self.test_getFilesUTCDay()
+
     def test_getFilesStartTime(self):
         """getFiles with a start time"""
         expected = [
@@ -617,6 +623,11 @@ class DBUtilsGetTests(TestSetup):
         actual = sorted([v.filename for v in val])
         self.assertEqual(expected, actual)
 
+    def test_getFilesStartTimeUnixTime(self):
+        """getFiles with a start time, lookup by Unix time"""
+        self.dbu.addUnixTimeTable()
+        self.test_getFilesStartTime()
+
     def test_getFilesByProductTime(self):
         """getFiles by the UTC date of data"""
         expected = ['ect_rbspb_0382_381_04.ptp.gz',
@@ -626,6 +637,11 @@ class DBUtilsGetTests(TestSetup):
                                              newest_version=True)
         actual = sorted([v.filename for v in val])
         self.assertEqual(expected, actual)
+
+    def test_getFilesByProductTimeUnixTime(self):
+        """getFiles by the UTC date of data, lookup by Unix time"""
+        self.dbu.addUnixTimeTable()
+        self.test_getFilesByProductTime()
 
     def test_getFilesByProductDate(self):
         """getFilesByProductDate"""

--- a/unit_tests/test_DButils.py
+++ b/unit_tests/test_DButils.py
@@ -1427,6 +1427,14 @@ class TestWithtestDB(unittest.TestCase):
         self.assertEqual(1, i.product_id)
         self.assertEqual('0', i.shasum)
 
+    def test_addFileUnixTime(self):
+        """Tests if addFile populates Unix time"""
+        self.dbu.addUnixTimeTable()
+        fID = self.addGenericFile(1)
+        r = self.dbu.getEntry('Unixtime', fID)
+        self.assertEqual(1262304000, r.unix_start)
+        self.assertEqual(1262390400, r.unix_stop)
+
     def test_addInstrument(self):
         """Tests if addInstrument is succesful"""
         iID = self.dbu.addInstrument(instrument_name="testing_{MISSION}_{SPACECRAFT}_Instrument",

--- a/unit_tests/test_DButils.py
+++ b/unit_tests/test_DButils.py
@@ -1886,6 +1886,26 @@ class TestWithtestDB(unittest.TestCase):
             "'DButils' object has no attribute 'Nonexistent'",
             cm.exception.message)
 
+    def testAddUnixTimeTable(self):
+        """Add the table with Unix time"""
+        self.dbu.addUnixTimeTable()
+        r = self.dbu.getEntry('Unixtime', 1)
+        f = self.dbu.getEntry('File', 1)
+        # Verify the preconditions, UTC times are what expect
+        self.assertEqual(
+            datetime.datetime(2016, 1, 2),
+            f.utc_start_time)
+        self.assertEqual(
+            datetime.datetime(2016, 1, 3),
+            f.utc_stop_time)
+        # Verify the Unix time conversions
+        self.assertEqual(1451692800, r.unix_start)
+        self.assertEqual(1451779200, r.unix_stop)
+        with self.assertRaises(RuntimeError) as cm:
+            self.dbu.addUnixTimeTable()
+        self.assertEqual('Unixtime table already seems to exist.',
+                         str(cm.exception))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR speeds up the calculation of possible output files and thus closes #23. This works by JOINing the file table with a table containing Unix times and doing the search using that table. If that table doesn't exist, the old (slower) code will be used. Included is a script to migrate databases by adding this table and populating it with existing file entries; eventually this script can be expanded to perform other migration tasks (e.g. the yesterday/tomorrow columns) as part of #7.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] Major new functionality has appropriate Sphinx documentation
- [X] (N/A, see below) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked in the description (e.g. `See issue #` or `Closes #`)

No changelog entry since it doesn't exist, release notes pending (#28) 
