### PR TITLE
addFile: fix utc_start_time/stop_time as dates with Unix time table

### DIFF
--- a/dbprocessing/DButils.py
+++ b/dbprocessing/DButils.py
@@ -1456,6 +1456,8 @@ class DButils(object):
         :return: file_id of the newly inserted file
         :rtype: long
         """
+        utc_start_time = Utils.toDatetime(utc_start_time)
+        utc_stop_time = Utils.toDatetime(utc_stop_time)
         d1 = self.File()
         d1.filename = filename
         d1.utc_file_date = utc_file_date

--- a/unit_tests/test_DButils.py
+++ b/unit_tests/test_DButils.py
@@ -1427,6 +1427,36 @@ class TestWithtestDB(unittest.TestCase):
         self.assertEqual(1, i.product_id)
         self.assertEqual('0', i.shasum)
 
+    def test_addFileNonDatetimeStart(self):
+        """Add a file with a non-datetime utc_start_time"""
+        v = Version.Version(1, 0, 0)
+        kwargs = {
+            'filename': "testing_file_1.0.0.file",
+            'data_level': 0,
+            'version': v,
+            'file_create_date': datetime.date(2010, 1, 1),
+            'exists_on_disk': 1,
+            'utc_file_date': datetime.date(2010, 1, 1),
+            'utc_start_time': datetime.date(2010, 1, 1),
+            'utc_stop_time': datetime.datetime(2010, 1, 2, 0, 0, 0),
+            'product_id': 1,
+            'shasum': '0'
+        }
+        # Make with a start date instead of datetime
+        fID = self.dbu.addFile(**kwargs)
+        f = self.dbu.getEntry('File', fID)
+        self.assertEqual(datetime.datetime(2010, 1, 1),
+                         f.utc_start_time)
+        # Do the same thing with the Unix time table
+        self.dbu.addUnixTimeTable()
+        kwargs.update({
+            'filename': "testing_file_1.1.0.file",
+            'version': Version.Version(1, 1, 0)
+        })
+        fID = self.dbu.addFile(**kwargs)
+        r = self.dbu.getEntry('Unixtime', fID)
+        self.assertEqual(1262304000, r.unix_start)
+
     def test_addFileUnixTime(self):
         """Tests if addFile populates Unix time"""
         self.dbu.addUnixTimeTable()


### PR DESCRIPTION
`addFile` used to work if the `utc_start_time` or `utc_stop_time` were passed in as a `date` instead of `datetime`--it just put to midnight of that day. It's a little bit weird, but the inspector output tends to get passed straight to `addFile` and I managed to write a few inspectors that did this in some circumstances. I figured if I could make that mistake it might happen again. With #31 this no longer worked, since they were treated as datetimes before hitting the database. This PR explicitly converts to datetime.

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] (N/A) Major new functionality has appropriate Sphinx documentation
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked in the description (e.g. `See issue #` or `Closes #`)
