### PR TITLE
Fix Unix time table calculation to maintain file day

### DIFF
--- a/dbprocessing/DButils.py
+++ b/dbprocessing/DButils.py
@@ -1492,6 +1492,8 @@ class DButils(object):
             r.file_id = d1.file_id
             # Round times down so they don't slide into next second
             # (and potentially next day)
+            # If changed, also change getFiles, addUnixTimeTable,
+            # updateUnixTime.py
             r.unix_start = None if utc_start_time is None \
                            else int((utc_start_time - unx0)\
                                     .total_seconds())
@@ -1760,6 +1762,7 @@ class DButils(object):
         # and non-truncated start time of file is 1.6) but better than
         # missing a file that does overlap (e.g requested start time is 1.2
         # and non-truncated file start is 1.6, truncates to 1.0)
+        # If changed, also change addFile, addUnixTimeTable, updateUnixTime.py
         if startTime is not None:
             startTime = Utils.toDatetime(startTime)
             if unixtime:
@@ -2683,6 +2686,7 @@ class DButils(object):
         for f in self.getFiles(): # Populate the times
             r = self.Unixtime()
             r.file_id = f.file_id
+            # If changed, also change addFile, getFiles, updateUnixTime.py
             r.unix_start = int((f.utc_start_time - unx0)\
                                .total_seconds())
             r.unix_stop = int((f.utc_stop_time - unx0)\

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -233,6 +233,8 @@ In a given directory, make symlinks to all the newest versions of files into ano
 
 .. warning:: There's no documentation on the config file
 
+.. _MigrateDB:
+
 MigrateDB.py
 ------------
 .. program:: MigrateDB.py
@@ -391,6 +393,20 @@ Goes into the database and update the shasum entry for a file that is changed af
 
 .. option:: infile File to update the shasum of
 .. option:: -m <dbname>, --mission <dbname> Selected mission database
+
+updateUnixTime.py
+-----------------
+.. program:: updateUnixTime.py
+
+Rewrites all Unix timestamps in a file, recalculating them from the UTC
+start/stop time. This is not needed if adding a Unix timestamp table
+to an existing database (see :ref:`MigrateDB`); it is only required
+if the algorithm for populating the Unix timestamps changes and a database
+has been created with the older algorithm.
+
+.. option:: -m <dbname>, --mission <dbname>
+
+   Selected mission database
 
 weeklyReport.py:
 ----------------

--- a/scripts/updateUnixTime.py
+++ b/scripts/updateUnixTime.py
@@ -44,6 +44,8 @@ def main(mission):
     unx0 = datetime.datetime(1970, 1, 1)
     for f in dbu.getFiles(): # Populate the times
         r = dbu.getEntry('Unixtime', f.file_id)
+        # If changed, also change addFile, addUnixTimeTable, getFiles
+        # (all in DButils)
         r.unix_start = int((f.utc_start_time - unx0)\
                            .total_seconds())
         r.unix_stop = int((f.utc_stop_time - unx0)\

--- a/scripts/updateUnixTime.py
+++ b/scripts/updateUnixTime.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+"""Update Unix file timestamps in a database from the UTC start/stop time"""
+
+import argparse
+import datetime
+import sys
+
+import dbprocessing.DButils
+
+
+def parse_args(argv=None):
+    """Parse arguments for this script
+
+    Parameters
+    ==========
+    argv : list
+        Argument list, default from sys.argv
+
+    Returns
+    =======
+    options : argparse.Values
+        Arguments from command line, from flags and non-flag arguments.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-m", "--mission", required=True,
+                        help="selected mission database")
+    options = parser.parse_args(argv)
+    return vars(options)
+
+
+def main(mission):
+    """Rewrite Unix timestamps for a database.
+
+    Opens an existing database and rewrites all Unix timestamps based on the
+    UTC file timestamps.
+
+    Parameters
+    ==========
+    mission : str
+        Path to the mission file
+    """
+    dbu = dbprocessing.DButils.DButils(mission)
+    unx0 = datetime.datetime(1970, 1, 1)
+    for f in dbu.getFiles(): # Populate the times
+        r = dbu.getEntry('Unixtime', f.file_id)
+        r.unix_start = int((f.utc_start_time - unx0)\
+                           .total_seconds())
+        r.unix_stop = int((f.utc_stop_time - unx0)\
+                          .total_seconds())
+    dbu.commitDB()
+
+
+if __name__ == "__main__":
+    main(**parse_args())
+


### PR DESCRIPTION
The Unix time table truncated start times for files to integer and used ceiling for end times. This means that a file with a timestamp late in the day (e.g. 23:59:59.600) could potentially be treated as if it had data in the next day, so for instance it would be passed in as an input for any processes that were using the next day. This PR does a truncate-to-integer in all cases, in both calculating the values for storage in the database and in converting datetimes to Unix time for lookup in the database.

Using an integer here is reasonable for speed (and not having to change database format yet again), and in general we don't operate with sub-second accuracy. We just need to do the Right Thing (or the Justifiable Thing) when there are sub-second timestamps. Because the beginning of a second is considered to be part of the second but the "end" of a second is not (i.e. second 5 _includes_ 5.000000 but _excludes_ 6.00000), this treatment guarantees that all moments within a given second are treated the same. (And thus, by induction, all moments within a minute, hour, day, etc.).

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] (N/A) Major new functionality has appropriate Sphinx documentation
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked in the description (e.g. `See issue #` or `Closes #`)

<!--
Thank you so much for your PR!  The dbprocessing community appreciates your
help and feedback.  To help us review your contribution, please
consider the following points:

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Fix buildChildren when input files span days".
  Avoid non-descriptive titles such as "Bug fix" or "Updates".

- The PR summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues. If the PR resolves an issue, please write this in the summary
  so that github will automatically close the issue. E.g. "This PR resolves #1".

We understand that working with PRs can be tricky, even for seasoned contributors.
Please let us know if reviews are unclear or our recommendations seem like excessive work.
If you would like help in addressing a reviewer's comments, or if your PR hasn't been
reviewed in a reasonable timeframe please just comment again.
-->

