### PR TITLE
CircleCI: update apt cache before installing packages (fix CreateDBsabrs test)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ jobs:
            at: ~/.local
        - run:
            command: |
+             sudo apt update
              sudo apt install -y postgresql-client
              createdb -h localhost sndd -O root
              pip install --user psycopg2


### PR DESCRIPTION
Our `createpostgres` job in CircleCI is failing on the `apt-get` of `postgresql-client`. The problem appears to be that the apt cache on the base CircleCI image isn't necessarily up-to-date, so it's trying to download packages that no longer are on the Debian mirrors, as in https://discuss.circleci.com/t/random-404-when-doing-apt-get-install-postgresql-client/30286

This is probably why #38 is not currently mergeable.

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] (N/A) Major new functionality has appropriate Sphinx documentation
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked in the description (e.g. `See issue #` or `Closes #`)
