### PR TITLE
Build Sphinx docs in CI; check for warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,20 @@ jobs:
              createdb -h localhost sndd -O root
              pip install --user psycopg2
              python scripts/CreateDBsabrs.py
+  docs:
+    docker:
+      - image: circleci/python:2.7.18
+    steps:
+       - checkout
+       - attach_workspace:
+           at: ~/.local
+       - run:
+           command: |
+             pip install --user sphinx
+             pip install --user numpydoc
+             make -C sphinx html | tee doc_output.txt
+             # Fail (return nonzero) if there are warnings in outpus.
+             ! grep -e "^build succeeded.*warning.*$" < doc_output.txt
 
 workflows:
   main:
@@ -61,5 +75,8 @@ workflows:
          requires:
            - build
      - createpostgres:
+         requires:
+           - build
+     - docs:
          requires:
            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
              pip install --user sphinx numpy
              pip install --user numpydoc
              make -C sphinx html | tee doc_output.txt
-             # Fail (return nonzero) if there are warnings in outpus.
+             # Fail (return nonzero) if there are warnings in output.
              ! grep -e "^build succeeded.*warning.*$" < doc_output.txt
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
            at: ~/.local
        - run:
            command: |
-             pip install --user sphinx
+             pip install --user sphinx numpy
              pip install --user numpydoc
              make -C sphinx html | tee doc_output.txt
              # Fail (return nonzero) if there are warnings in outpus.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,7 @@ jobs:
            at: ~/.local
        - run:
            command: |
+             rm -f ./setup.cfg # So sphinx-build doesn't go in ~/dbUtils
              pip install --user sphinx numpy
              pip install --user numpydoc
              make -C sphinx html | tee doc_output.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,14 +45,14 @@ extensions = [
     'sphinx.ext.coverage',
     imgmath,
     'sphinx.ext.viewcode',
-    #'numpydoc',
+    'numpydoc',
     'sphinx.ext.inheritance_diagram',
     'sphinx.ext.autosummary',
     'sphinx.ext.extlinks',
 ]
 
 autosummary_generate = True
-#numpydoc_show_class_members = False
+numpydoc_show_class_members = False
 
 # # make it so TODOs will work
 # todo_include_todos = True


### PR DESCRIPTION
This PR adds a documentation build job to CircleCI to make sure the docs build without errors or warnings. This is helpful for catching errors in the documentation (as with the unit tests) but also cases where Sphinx might have changed, the intersphinx links aren't working, etc.

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] (N/A) Major new functionality has appropriate Sphinx documentation
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked in the description (e.g. `See issue #` or `Closes #`)
