### PR TITLE
More documentation of pull request processing; release notes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugreport.md
+++ b/.github/ISSUE_TEMPLATE/bugreport.md
@@ -9,6 +9,9 @@ taking the time to report a dbprocessing issue. Please
 describe the issue in detail, and fill in the applicable fields
 below.
 
+Please also include a title that is descriptive, but not too long (under
+about 80 characters), as it will be included in release notes.
+
 You can delete the sections that don't apply to your
 issue. For example, if a feature is inadequately
 described, simply delete all sections below and 

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -10,6 +10,9 @@ taking the time to suggest an enhancement. Please describe
 your desired enhancement in detail, including at least
 one possible use case.
 
+Please also include a title that is descriptive, but not too long (under
+about 80 characters), as it will be included in release notes.
+
 You can use the sections below if they're helpful in
 describing the enhancement, or delete any that aren't.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,13 @@
 New code is easier to review, integrate and maintain if it's
 consistent with the style of the rest of the dbprocessing code.
 Please try to follow as much of this checklist as you can for
-your PR. If you can't hit everything, or don't know how to,
-then submit the PR and the rest can be discussed during review.
+your PR. If a given item is not relevant to your PR, please check
+it off, add "(N/A)" to the start of the line, and include a
+description below the checklist.
+
+If you don't know how to complete something in the checklist, go
+ahead and submit the PR as a draft and ask for help.
+
 Some additional suggestions are given below.
 
 Please also see our Code of Conduct so that the dbprocessing community

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,7 +24,7 @@ pull request description.
 - [ ] Major new functionality has appropriate Sphinx documentation
 - [ ] Added an entry to release notes if fixing a major bug or providing a major new feature
 - [ ] New features and bug fixes should have unit tests
-- [ ] Relevant issues are linked in the description (e.g. `See issue #` or `Closes #`)
+- [ ] Relevant issues are linked in the description (use `Closes #` if this PR closes the issue, or some other reference, such as `See #` if it is related in some other way)
 
 <!--
 Thank you so much for your PR!  The dbprocessing community appreciates your

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@ pull request description.
 - [ ] New code has inline comments where necessary
 - [ ] Any new modules, functions or classes have docstrings consistent with dbprocessing style
 - [ ] Major new functionality has appropriate Sphinx documentation
-- [ ] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
+- [ ] Added an entry to release notes if fixing a major bug or providing a major new feature
 - [ ] New features and bug fixes should have unit tests
 - [ ] Relevant issues are linked in the description (e.g. `See issue #` or `Closes #`)
 
@@ -28,8 +28,9 @@ consider the following points:
 
 - Do not create the PR out of master, but out of a separate branch.
 
-- The PR title should summarize the changes, for example "Fix buildChildren when input files span days".
-  Avoid non-descriptive titles such as "Bug fix" or "Updates".
+- The PR title will be included directly in the release notes. It should
+  summarize the changes, for example "Fix buildChildren when input files
+  span days". Avoid non-descriptive titles such as "Bug fix" or "Updates".
 
 - The PR summary should provide at least 1-2 sentences describing the pull request
   in detail (Why is this change required?  What problem does it solve?) and

--- a/developer/README.txt
+++ b/developer/README.txt
@@ -5,3 +5,6 @@ functionals:
     Set ups for task-specific functional tests or test configurations. Should
     be kept minimal and not include databases (databases should be created
     from configuration file.) Include a README.
+
+scripts:
+    Scripts useful in development, such as for making a release.

--- a/developer/scripts/git_notes.py
+++ b/developer/scripts/git_notes.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python
+
+import argparse
+import datetime
+import operator
+import os.path
+import re
+import sys
+import time
+
+import git
+import github
+
+
+class NoteCreator(object):
+    """Class to grab information for release notes from github"""
+
+    def __init__(self, repodir, rev=None, token=None):
+        """Initialize variables
+
+        Parameters
+        ----------
+        repodir : str
+            Path to the dbprocessing repository checkout
+
+        rev : str, optional
+            Revision (tag) of the last release. Will only get information
+            from this point on. Default: most recent tag.
+
+        token : str, optional
+            Github `access token <https://docs.github.com/en/
+            free-pro-team@latest/github/authenticating-to-github/
+            creating-a-personal-access-token>`_. This is optional but
+            anonymous access might be `throttled
+            <https://developer.github.com/v3/#rate-limiting>`_
+        """
+        self.repo = git.Repo(repodir)
+        """Access to the local checked-out repo"""
+        if rev is None:
+            commit = sorted(
+                self.repo.tags, key=lambda x: x.commit.committed_date)[-1]\
+                .commit
+        else:
+            commit = self.repo.commit(rev=rev)
+        self.last_release = datetime.datetime(
+            *time.gmtime(commit.committed_date)[:6])
+        """Time of the last release"""
+        gh = github.Github(token)
+        self.github = gh.get_repo('spacepy/dbprocessing')
+        """Access to the dbprocessing github repo"""
+
+    def main(self):
+        """Perform all the operations of the script"""
+        issues, prs = self.get_issues()
+        closed_issues = self.print_prs(prs)
+        self.print_issues(issues, closed_issues)
+
+    def get_issues(self):
+        """Get all closed issues/PRs from the last release
+
+        Returns
+        =======
+        issues, prs : list
+            All the issues (as :class:`~github.Issue.Issue`) and pull requests
+            (:class:`~github.PullRequest.PullRequest`) closed since
+            :data:`last_release`. Sorted ascending by close date.
+        """
+        issues = self.github.get_issues(state='closed', since=self.last_release)
+        issues = [i for i in issues
+                  if i.closed_at >= self.last_release]
+        # Split into PRs...
+        prs = [self.github.get_pull(p.number) for p in issues
+               if p.pull_request is not None]
+        prs = [p for p in prs if p.merged and p.base.ref == 'master']
+        prs.sort(key=operator.attrgetter('merged_at'))
+        # ... and non-prs
+        issues = [i for i in issues if i.pull_request is None]
+        issues.sort(key=operator.attrgetter('closed_at'))
+        return issues, prs
+
+    def print_prs(self, prs):
+        """Print out information on the closed PRs
+
+        Parameters
+        ==========
+        prs : list
+            All the pull requests to print information about
+
+        Returns
+        =======
+        list
+            All the issue numbers that were closed by these pull requests
+        """
+        # Also have available body
+        # There should be .labels in PRs but maybe that's just in
+        # later versions...issues have "get_labels". This is also available in
+        # PRs that are treated as issue objects, but not once they've been
+        # cast to PR, so maybe that's an improvement for the future.
+        # Can only get issues closed by PR by parsing the body
+        # of the pull request for the magic words (p.body)
+        # https://github.community/t/github-api-how-to-get-issues-closed-by-a-pullrequest/14114
+        pat = re.compile(
+            r'(?:(?:close|resolve)(?:s|d)?|fix(?:es|ed)?) \#(\d+)',
+            re.IGNORECASE)
+        all_closed = []
+        print('\nPull requests merged this release')
+        print('^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^')
+        if not prs:
+            print('None')
+        for p in prs:
+            # Remove HTML comments in case someone has magic words in comment
+            body_stripped = re.sub(r'<!--.*?-->', '', p.body, flags=re.DOTALL)
+            closed = [int(i) for i in re.findall(pat, body_stripped)]
+            all_closed.extend(closed)
+            commit_url = self.github.get_commit(p.merge_commit_sha)\
+                                    .commit.html_url
+            print('')
+            title = 'PR `{n} <{url}>`_: {title} (`{commit} <{commit_url}>`_)'\
+                    .format(commit=p.merge_commit_sha[:8],
+                            commit_url=commit_url,
+                            n=p.number, title=p.title, url=p.html_url)
+            print(title)
+            for c in closed:
+                i = self.github.get_issue(c)
+                print('\n    `{n} <{url}>`_: {title}'.format(
+                    n=c, title=i.title, url=i.html_url))
+        return list(set(all_closed))
+
+    def print_issues(self, issues, closed_issues):
+        """Print out information on closed issues
+
+        Parameters
+        ==========
+        issues : list
+            All the issues to print information about
+        closed_issues : list
+            Issue numbers that have been closed in PRs, so can be
+            treated differently.
+        """
+        issues = [i for i in issues if i.number not in closed_issues]
+        print('\nOther issues closed this release')
+        print('^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^')
+        if not issues:
+            print('None')
+        for i in issues:
+            print('')
+            print('`{n} <{url}>`_: {title}'.format(
+                n=i.number, title=i.title, url=i.html_url))
+
+    @staticmethod
+    def parse_args(argv=None):
+        """Parse command line arguments
+
+        Parameters
+        ----------
+        argv : list, optional
+            Command line arguments, default from :data:`sys.argv`
+
+        Returns
+        -------
+        dict
+            Keyword arguments suitable for passing to :meth:`__init__`.
+        """
+        parser = argparse.ArgumentParser()
+        parser.add_argument('-t', '--token',
+                            help='github access token, optional')
+        parser.add_argument('-r', '--rev',
+                            help='git rev (usually tag name) of last release')
+        kwargs = vars(parser.parse_args(argv))
+        kwargs['repodir'] = os.path.abspath(os.path.join(
+            os.path.dirname(__file__), '..', '..'))
+        return kwargs
+
+
+if __name__ == '__main__':
+    NoteCreator(**NoteCreator.parse_args()).main()
+    

--- a/docs/developer/code_standards.rst
+++ b/docs/developer/code_standards.rst
@@ -113,6 +113,9 @@ details. Each point in the bullet list must start with a single space,
 an asterisk, and another space; wrapped lines must be indented three
 spaces to align with the start of the line's text.
 
+If a commit closes an issue, include ``(Closes #x)`` at the end of the
+first-line summary. See also :doc:`pull_requests`.
+
 Lines must not exceed 76 characters (``git log`` adds a
 four-space indent to the commit message on display).
 

--- a/docs/developer/documentation.rst
+++ b/docs/developer/documentation.rst
@@ -127,3 +127,7 @@ More information on possible locations for these files is (somewhat obscurely)
 in the `github documentation for setting default versions <https://
 docs.github.com/en/github/building-a-strong-community/
 creating-a-default-community-health-file>`_.
+
+Release Notes
+=============
+See :doc:`release`.

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -13,6 +13,7 @@ Developer Information
    pull_requests
    repository
    structure
+   release
    notes	      
    todo
    ../CONTRIBUTING

--- a/docs/developer/pull_requests.rst
+++ b/docs/developer/pull_requests.rst
@@ -33,9 +33,6 @@ request <https://docs.github.com/en/github/
 collaborating-with-issues-and-pull-requests/creating-a-pull-request>`_
 against ``spacepy/dbprocessing master``.
 
-When creating the PR, following the provided template as closely as
-possible will facilitate its review.
-
 The preferred flow of code is summarized:
 
     1. Code is created on a `branch <https://docs.github.com/en/github/
@@ -50,6 +47,28 @@ The preferred flow of code is summarized:
        collaborating-with-issues-and-pull-requests/syncing-a-fork>`_ after
        the pull request has been merged.
 
+When creating the PR, following the provided template as closely as
+possible will facilitate its review. This template includes a checklist;
+consider every item on the list and check it if completed. If an item
+is not relevant, check it, add "(N/A)" to the start of the line, and
+include an explanation below the checklist. E.g.::
+
+   - [X] ...
+   - [X] (N/A) Major new functionality has appropriate Sphinx documentation
+   - [X] ...
+
+   This is a pure bugfix, no new functionality or documentation.
+
+If working in a draft PR, adding more checklists to the description is
+fine. A PR will be reviewed when:
+
+   1. All checklists are checked (this shows in the pull request list
+      as e.g. "8 of 8").
+   2. The PR is marked ready for review, i.e. not draft.
+   3. All CI checks pass.
+
+Feel free to request help before this point (tag the PR with ``question``
+to make it stand out).
 
 Reviews and updating
 ====================
@@ -61,6 +80,8 @@ reviews and comments are welcome from all.
 Our experience has been that using the github interface to suggest
 line-by-line diffs doesn't work very well; line-by-line comments are fine
 (and helpful!)
+
+You can request a specific reviewer, but are not required to.
 
 The review will mostly evaluate whether the PR checklist has been met,
 all tests pass, and the contribution meets requirements in the :doc:`index`.

--- a/docs/developer/pull_requests.rst
+++ b/docs/developer/pull_requests.rst
@@ -145,7 +145,7 @@ about-merge-methods-on-github>`_. This maintains a linear history and
 also makes it clear both who authored the commit and who approved it
 for the repository.
 
-One all conditions are met, a developer can `perform the merge
+Once all conditions are met, a developer can `perform the merge
 <https://docs.github.com/en/github/
 collaborating-with-issues-and-pull-requests/merging-a-pull-request>`_.
 

--- a/docs/developer/pull_requests.rst
+++ b/docs/developer/pull_requests.rst
@@ -6,7 +6,8 @@ Documented here is the procedure for working with pull requests (PRs)
 in the ``dbprocessing`` project. It does not include details on working
 with git and github in general; relevant docs are linked.
 
-If you can't figure it out, please do your best and ask for help in the PR.
+If you can't figure it out, please do your best and ask for help in the PR
+(use the ``question`` tag).
 
 .. contents::
    :local:
@@ -48,7 +49,18 @@ The preferred flow of code is summarized:
        the pull request has been merged.
 
 When creating the PR, following the provided template as closely as
-possible will facilitate its review. This template includes a checklist;
+possible will facilitate its review.
+
+Use ``closes #x`` in the description of the PR if merging the PR will
+close that issue. (``Closes`` is preferred to ``fixes`` because e.g
+closing an enhancement issue is not exactly a fix.) Referencing
+other related issues or PRs is also encouraged, e.g. ``see #x``.
+Avoid the `issue-closing magic words <https://docs.github.com/en/
+free-pro-team@latest/github/managing-your-work-on-github/
+linking-a-pull-request-to-an-issue>`_ unless closing the issue,
+in which case ``closes`` is preferred.
+
+The template includes a checklist;
 consider every item on the list and check it if completed. If an item
 is not relevant, check it, add "(N/A)" to the start of the line, and
 include an explanation below the checklist. E.g.::

--- a/docs/developer/release.rst
+++ b/docs/developer/release.rst
@@ -1,0 +1,93 @@
+##################
+Building a release
+##################
+
+.. contents::
+   :depth: 2
+   :local:
+
+Release notes
+=============
+
+The release notes should be updated with the date of release and checked
+for completeness and accuracy. The release series (x.y) is formatted
+as a section, the actual release (x.y.z) as a subsection, and the possible
+subsubsections follow here.
+
+Normally release notes should be updated as functionality is added/changed,
+not only at release time.
+
+Release subsubsections
+----------------------
+If any of these is not used for a particular release, it may be omitted.
+
+New features
+^^^^^^^^^^^^
+Brief description of any features that were added in this release. Link to
+appropriate documentation of the feature (e.g. user documentation such
+as the script, or API documentation). Link to either the Github pull request
+that introduced the feature or the enhancement request issue related to it,
+whichever has the most information.
+
+This includes added functionality in existing scripts, functions, and classes.
+
+Deprecations and removals
+^^^^^^^^^^^^^^^^^^^^^^^^^
+Any functionality that has been removed or is planned to be removed
+(deprecated). This includes API deprecations. For deprecated features,
+link their documentation; for deprecated or removed, link the appropriate
+replacement.
+
+This also includes any changes in support for older database versions.
+
+Dependency requirements
+^^^^^^^^^^^^^^^^^^^^^^^
+Any changes to dependencies (e.g. new dependencies, new minimum versions.)
+
+Major bugfixes
+^^^^^^^^^^^^^^
+Fixed bugs that are likely to be of interest to a substantial fraction of
+dbprocessing users. Omit very obscure bugs that are unlikely to be hit;
+they will be included in the full list of closed issues.
+
+Normally link to the relevant Github issue, although in some cases the pull
+request that closed the bug may be more appropriate.
+
+Other changes
+^^^^^^^^^^^^^
+Any other changes that are likely to be of interest to a substantial fraction
+of users and do not fit the above categories. In particular, any changes
+in behavior or expectations that are not new features or bug fixes.
+
+Pull requests merged this release
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Should be generated and pasted into release notes at release time; see below.
+
+Other issues closed this release
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Also generated at release time.
+
+PRs and issues in release notes
+===============================
+The list of pull requests and issues closed in a release is created from the
+script ``git_notes.py`` in ``developer/scripts``.
+
+This script requires `GitPython <https://gitpython.readthedocs.io/en/
+stable/>`_ and `PyGithub <https://pygithub.readthedocs.io/en/latest/
+introduction.html>`_. On Ubuntu these are packaged as ``python-git`` and
+``python-github`` (or ``python3-git`` and ``python3-github``.)
+
+You need a `Github token <https://docs.github.com/en/free-pro-team@latest/
+github/authenticating-to-github/creating-a-personal-access-token>`_ to avoid
+`throttling <https://developer.github.com/v3/#rate-limiting>`_. No scopes are
+required.
+
+Run the script with your token and the name of the last release tag. The
+relevant rST will be sent to stdout; redirect to a file, and copy/paste into
+the release notes. Do not do this on a shared machine, as the token will be
+visible in the process table.
+
+.. code-block:: sh
+
+    python ./git_notes.py -t GITHUB_TOKEN -r release-0.1
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,6 +4,7 @@ dbprocessing
    :maxdepth: 1
 
    README
+   release_notes
    developer/index
    scripts
    ConfigurationFiles

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,0 +1,45 @@
+=============
+Release Notes
+=============
+
+.. contents::
+   :depth: 2
+   :local:
+
+0.1 Series
+==========
+
+0.1 (xxxx-xx-xx)
+----------------
+This is the first public packaged release of dbprocessing. For the convenience
+of those working directly from git checkouts, these release notes summarize
+changes made since the creation of the public repository on 2020-07-15.
+
+New features
+^^^^^^^^^^^^
+Support for processes that take no input was added, as part of many
+enhancements to :ref:`scripts_DBRunner`  (`26 <https://github.com/spacepy/
+dbprocessing/pull/26>`_).
+
+Deprecations and removals
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Dependency requirements
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Major bugfixes
+^^^^^^^^^^^^^^
+
+Fixed :class:`~dbprocessing.dbprocessing.ProcessQueue.buildChildren` on
+older databases without ``yesterday`` and ``tomorrow`` columns in the
+``Productprocesslink`` table (`20 <https://github.com/spacepy/dbprocessing/
+issues/20>`_).
+
+Other changes
+^^^^^^^^^^^^^
+
+Pull requests merged this release
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Other issues closed this release
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -41,5 +41,59 @@ Other changes
 Pull requests merged this release
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+..
+   Normally these aren't committed to the repository until release time,
+   but the script to generate this section has been run early to allow
+   tweaking of the format before release.
+
+PR `8 <https://github.com/spacepy/dbprocessing/pull/8>`_: Fix unit tests for scripts (`44690a95 <https://github.com/spacepy/dbprocessing/commit/44690a955d41544af9a10c9c316221cc4154bf14>`_)
+
+PR `13 <https://github.com/spacepy/dbprocessing/pull/13>`_: Circleci project setup (`c99ffc43 <https://github.com/spacepy/dbprocessing/commit/c99ffc43961ff389ff3d8645ab92ead41af4d9e0>`_)
+
+PR `18 <https://github.com/spacepy/dbprocessing/pull/18>`_: Fix handling of inspector regex for ECT (`61a2215e <https://github.com/spacepy/dbprocessing/commit/61a2215ec449ebc253dab2e98716c734dd1092e2>`_)
+
+PR `1 <https://github.com/spacepy/dbprocessing/pull/1>`_: Basic respository organization (`362a0b72 <https://github.com/spacepy/dbprocessing/commit/362a0b72b868d5ad6019784acd6052d07b8d2a35>`_)
+
+PR `19 <https://github.com/spacepy/dbprocessing/pull/19>`_: test_checkIncoming update to guarantee directory state (Closes #17) (`16899b2c <https://github.com/spacepy/dbprocessing/commit/16899b2c8e83236b1687bfe50d1bea304811efc2>`_)
+
+    `17 <https://github.com/spacepy/dbprocessing/issues/17>`_: test_checkIncoming  fails when a direction on my system is not empty
+
+PR `21 <https://github.com/spacepy/dbprocessing/pull/21>`_: Fix _getRequiredProducts/getInputProductID on old DB (Closes #20) (`07f3e3a1 <https://github.com/spacepy/dbprocessing/commit/07f3e3a1ace8f4f72e482e2dd47b951fe00d140d>`_)
+
+    `20 <https://github.com/spacepy/dbprocessing/issues/20>`_: 'Productprocesslink' has no attribute 'yesterday', old database
+
+PR `24 <https://github.com/spacepy/dbprocessing/pull/24>`_: Testing changes in preparation for no-input support (`24ca0b57 <https://github.com/spacepy/dbprocessing/commit/24ca0b577b0487393a333d601b59212cd086a236>`_)
+
+PR `27 <https://github.com/spacepy/dbprocessing/pull/27>`_: Run unit tests in CircleCI (`1fe1ef46 <https://github.com/spacepy/dbprocessing/commit/1fe1ef4648768c151cd895c96f725b3d3ae112e7>`_)
+
+    `16 <https://github.com/spacepy/dbprocessing/issues/16>`_: Document CircleCI setup and github integration
+
+    `15 <https://github.com/spacepy/dbprocessing/issues/15>`_: Execute unit tests in CircleCI
+
+PR `26 <https://github.com/spacepy/dbprocessing/pull/26>`_: DBRunner enhancements for ingest, update-only, force (Closes #9) (`5c05a165 <https://github.com/spacepy/dbprocessing/commit/5c05a165ed0072770a34cffa3c0d7894203af6f8>`_)
+
+    `9 <https://github.com/spacepy/dbprocessing/issues/9>`_: Support products with no input
+
+PR `31 <https://github.com/spacepy/dbprocessing/pull/31>`_: Speed up getFiles by start/stop time (Closes #23) (`b5f30ef3 <https://github.com/spacepy/dbprocessing/commit/b5f30ef366e63fdfb846ca688f98a61ec782436e>`_)
+
+    `23 <https://github.com/spacepy/dbprocessing/issues/23>`_: ProcessQueue "Command Build Progress" is slow
+
+PR `36 <https://github.com/spacepy/dbprocessing/pull/36>`_: addFile: fix utc_start_time/stop_time as dates with Unix time table (`333e47dc <https://github.com/spacepy/dbprocessing/commit/333e47dc7ef320ebd941d06e62be4414d0586e22>`_)
+
+PR `39 <https://github.com/spacepy/dbprocessing/pull/39>`_: CircleCI: update apt cache before installing packages (fix CreateDBsabrs test) (`00922ed5 <https://github.com/spacepy/dbprocessing/commit/00922ed5404c92607849ee99334c4eddc825e2d3>`_)
+
+PR `38 <https://github.com/spacepy/dbprocessing/pull/38>`_: Fix Unix time table calculation to maintain file day (`20afffc4 <https://github.com/spacepy/dbprocessing/commit/20afffc47c2d8d30018af953372c59fa0d82d87a>`_)
+
+PR `41 <https://github.com/spacepy/dbprocessing/pull/41>`_: remove the #! to python2.6 in favor of python, this was making my system barf that wants to use 2.7 (`8e5d3ae4 <https://github.com/spacepy/dbprocessing/commit/8e5d3ae432fb35227c74bc5615422cf456b39578>`_)
+
 Other issues closed this release
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+..
+   Normally these aren't committed to the repository until release time,
+   but the script to generate this section has been run early to allow
+   tweaking of the format before release.
+
+`2 <https://github.com/spacepy/dbprocessing/issues/2>`_: Website not finding CSS
+
+`42 <https://github.com/spacepy/dbprocessing/issues/42>`_: PR checklist calls for CHANGELOG update, yet there is no changelog

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -95,6 +95,8 @@ Show files in database but not on disk. Additionally, this can remove files from
 .. option:: --startID The File id to start on
 .. option:: -v, --verbose Print out each file as it is checked
 
+.. _scripts_DBRunner:
+
 DBRunner.py
 -----------
 .. program:: DBRunner.py


### PR DESCRIPTION
This PR adds an initial release notes setup (closes #28), including auto-generated list of closed issues/PRs. That issue contains some example of the output and I suspect we might want to tweak the formatting a bit; it's fairly coarse.

It documents how to mark a PR ready for review (closes #30).

And it documents the Github magic words (closes #29). I think "closes" is probably the preferred word here because "fixes" seems less applicable to e.g. enhancement, but I'm open to objections. I'm also open to saying we don't have a standard, just use a word that does the closing. I also documented using them in both the PR and the commit; I think it helps tie everything together, but open to changing that.

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] Major new functionality has appropriate Sphinx documentation
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked in the description (e.g. `See issue #` or `Closes #`)

This PR includes no dbprocessing functionality, but does include code to help prepare the release notes. That's to-standard although it doesn't have tests (it's not particularly testable code.)
