### PR TITLE
New linkUningested script: find files not in database and symlink for import

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -21,6 +21,11 @@ Support for processes that take no input was added, as part of many
 enhancements to :ref:`scripts_DBRunner`  (`26 <https://github.com/spacepy/
 dbprocessing/pull/26>`_).
 
+New script :ref:`scripts_linkUningested` to find files which match product
+format but are not in database, and symlink them to the incoming directory
+so they can be ingested (`54 <https://github.com/spacepy/dbprocessing/
+pull/54>`_).
+
 Deprecations and removals
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -210,6 +210,29 @@ link_missing_ql_mag_l2_mag.py:
 ------------------------------
 QL "required,", L2 "optional". We don't support "either or but prefer this one", so this links them together and the wrapper handles the actual priority
 
+.. _scripts_linkUningested:
+
+linkUningested.py
+-----------------
+.. program:: linkUningested.py
+
+Find all files that are in a directory associated with a product and match
+the product's file format, but are not in the database. Make a symbolic
+link to the incoming directory for each file (so they will be ingested
+on next run).
+
+.. option:: -m <dbname>, --mission <dbname>
+
+   Selected mission database.
+
+.. option:: -p <product>, --product <product>
+
+   Product name or product ID to check. Optional (default will check all
+   products), but highly recommended, since in particular ingestion of files
+   that are normally created rather than ingested as first-order inputs might
+   lead to odd results. Multiple products can be specified by specifying
+   more than once.
+
 magephem_dataToIncoming.py:
 ---------------------------
 What it says on tin. Delete?

--- a/scripts/linkUningested.py
+++ b/scripts/linkUningested.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+
+"""Find files that have not been ingested and link them to incoming"""
+
+import argparse
+import os.path
+import re
+import sys
+
+import dbprocessing.DButils
+import dbprocessing.DBstrings
+
+
+def parse_args(argv=None):
+    """Parse arguments for this script
+
+    Parameters
+    ----------
+    argv : list
+        Argument list, default from sys.argv
+
+    Returns
+    -------
+    kwargs : dict
+        Keyword arguments for :func:`main`.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-m", "--mission", required=True,
+                        help="selected mission database")
+    parser.add_argument("-p", "--product", action='append', dest="products",
+                        help="Product name or ID to check; specify multiple"
+                        " times for multiple products (default: all).")
+    options = parser.parse_args(argv)
+    return vars(options)
+
+
+def list_files(dbu, product):
+    """List all files on disk matching a product
+
+    Parameters
+    ----------
+    dbu : dbprocess.DButils.DButils
+        Open mission database
+
+    product : int or str
+        Product name or ID
+
+    Returns
+    -------
+    list
+        Path to all matching files relative to mission directory.
+    """
+    prod = dbu.getEntry('Product', product)
+    tb = dbu.getTraceback('Product', prod.product_id)
+    kwargs = {'INSTRUMENT': tb['instrument'].instrument_name,
+              'MISSION': tb['mission'].mission_name,
+              'PRODUCT': prod.product_name,
+              'SATELLITE': tb['satellite'].satellite_name,
+              'SPACECRAFT': tb['satellite'].satellite_name,
+              }
+    fmtr = dbprocessing.DBstrings.DBformatter()
+    pat = fmtr.re(prod.format, **kwargs)
+    proddir = fmtr.re(prod.relative_path, **kwargs)
+    md = os.path.normpath(dbu.getMissionDirectory())
+    # Because in general the relative path may include wildcards,
+    # we have to go through everything. It would be a nice improvement
+    # to find the static parts of the relative path and only hit that...
+    # spacepy.datamanager would do that for us.
+    pat = os.path.join(os.path.normpath(proddir), os.path.normpath(pat))
+    flist = (os.path.join(dn, f)[len(md) + 1:]
+             for dn, _, fnames in os.walk(md) for f in fnames)
+    flist = [f for f in flist if re.match(pat, f)]
+    return flist
+
+
+def indb(dbu, fname, prod):
+    """Checks if a filename is in database
+
+    Parameters
+    ----------
+
+    dbu : dbprocess.DButils.DButils
+        Open mission database
+
+    fname : str
+        Filename (no pathing)
+
+    product : int
+        Product ID
+
+    Returns
+    -------
+    bool
+        True if file with that name and product are present.
+    """
+    return bool(dbu.session.query(dbu.File)
+                .filter_by(product_id=prod, filename=fname).count())
+
+
+def main(mission, products=None):
+    """Check for files not in database
+
+    Find all files that match a product specification but are not in the
+    database and symlink them to incoming.
+
+    Parameters
+    ----------
+    mission : str
+        Path to the mission file
+
+    products : list
+        Product names or IDs to check; default all
+    """
+    dbu = dbprocessing.DButils.DButils(mission)
+    md = os.path.normpath(dbu.getMissionDirectory())
+    plist = dbu.getAllProducts() if products is None \
+            else [dbu.getEntry('Product', p) for p in products]
+    inc = dbu.getIncomingPath()
+    for prod in plist:
+        flist = list_files(dbu, prod.product_id)
+        missing = [f for f in flist
+                   if not indb(dbu, os.path.basename(f), prod.product_id)]
+        for m in missing:
+            os.symlink(os.path.join(md, m),
+                       os.path.join(inc, os.path.basename(m)))
+
+
+if __name__ == "__main__":
+    main(**parse_args())
+

--- a/unit_tests/test_all.py
+++ b/unit_tests/test_all.py
@@ -21,6 +21,7 @@ from test_Version import *
 from test_DBstrings import *
 from test_Utils import *
 from test_Inspector import *
+from test_linkUningested import *
 
 
 if __name__ == "__main__":

--- a/unit_tests/test_linkUningested.py
+++ b/unit_tests/test_linkUningested.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+"""Unit testing for linkUningested script"""
+
+import datetime
+import io
+import os.path
+import shutil
+import sys
+import tempfile
+import unittest
+
+import dbp_testing
+dbp_testing.add_scripts_to_path()
+
+import linkUningested
+import dbprocessing.dbprocessing
+
+
+class LinkUningestedTests(unittest.TestCase, dbp_testing.AddtoDBMixin):
+    """linkUningested tests"""
+
+    def test_parse_linkuningested_args(self):
+        """Parse the command line arguments"""
+        kwargs = linkUningested.parse_args(['-m', 'foo.sqlite'])
+        self.assertEqual(
+            'foo.sqlite', kwargs['mission'])
+        self.assertEqual(
+            None, kwargs['products'])
+        kwargs = linkUningested.parse_args(['-m', 'foo.sqlite', '-p', '1',
+                                            '-p', 'level1'])
+        self.assertEqual(
+            'foo.sqlite', kwargs['mission'])
+        self.assertEqual(
+            ['1', 'level1'], kwargs['products'])
+
+    def test_list_files(self):
+        """List files for product"""
+        td = tempfile.mkdtemp()
+        try:
+            testdb = os.path.join(td, 'emptyDB.sqlite')
+            shutil.copy2(os.path.join(dbp_testing.testsdir,
+                                      'emptyDB.sqlite'),
+                         testdb)
+            self.dbu = dbprocessing.DButils.DButils(testdb)
+            mis = self.dbu.addMission('mission', td, td)
+            sat = self.dbu.addSatellite('sat', mis)
+            self.dbu.addInstrument('inst', sat)
+            p1 = self.addProduct('product1',
+                                 format='{PRODUCT}/{Y}/prod1{Y}{m}{d}.txt')
+            p2 = self.addProduct('product2', format='prod2{Y}{m}{d}.txt')
+            os.makedirs(os.path.join(td, 'junk', 'product1', '2000'))
+            open(os.path.join(
+                td, 'junk', 'product1', '2000', 'prod120000101.txt'), 'w')\
+                .close()
+            open(os.path.join(
+                td, 'junk', 'product1', '2000', 'prod120000102.txt'), 'w')\
+                .close()
+            open(os.path.join(
+                td, 'junk', 'product1', '2000', 'somethingelse.txt'), 'w')\
+                .close()
+            open(os.path.join(td, 'junk', 'prod219990501.txt'), 'w').close()
+            open(os.path.join(td, 'junk', 'another.txt'), 'w').close()
+            res1 = linkUningested.list_files(self.dbu, p1)
+            res2 = linkUningested.list_files(self.dbu, p2)
+        finally:
+            try:
+                self.dbu.closeDB()
+                del self.dbu
+            except:
+                pass
+            shutil.rmtree(td)
+        self.assertEqual(
+            [os.path.join('junk', 'product1', '2000', 'prod12000010{}.txt'
+                          .format(i))
+             for i in range(1, 3)],
+            sorted(res1))
+        self.assertEqual(
+            [os.path.join('junk', 'prod219990501.txt')], sorted(res2))
+
+    def test_indb(self):
+        """See if files are in database"""
+        td = tempfile.mkdtemp()
+        try:
+            testdb = os.path.join(td, 'RBSP_MAGEIS.sqlite')
+            shutil.copy2(os.path.join(dbp_testing.testsdir,
+                                      'RBSP_MAGEIS.sqlite'),
+                         testdb)
+            dbu = dbprocessing.DButils.DButils(testdb)
+            self.assertTrue(linkUningested.indb(
+                dbu, 'rbspb_pre_MagEphem_OP77Q_20130906_v1.0.0.txt', 138))
+            self.assertFalse(linkUningested.indb(
+                dbu, 'rbspb_pre_MagEphem_OP77Q_20130906_v1.0.0.txt', 43))
+        finally:
+            try:
+                dbu.closeDB()
+                del dbu
+            except:
+                pass
+            shutil.rmtree(td)
+        
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds a new script which searches for files that are in their final location and match the filename format of a valid product, but have no records in the database. It then makes a symbolic link from that file into the incoming directory.

It's worth explaining the dbp feature that's behind this. Normally files are put into the incoming directory and dbprocessing puts them in their final location. But it's handy to be able to synchronize an entire tree (e.g. via rsync) and set up dbprocessing so that the "final location" of a file is exactly the place where it gets synced--then dbp doesn't need to move it, but definitely needs to ingest it so it's aware of the file. The way to do this is make a symbolic link in incoming that links to the file--then dbprocessing does the ingest and removes the symlink, leaving the file in place. Right now the scripts that do this are mission-specific but I hope to have a generic one at some point.

If, however, one has messed up the normal sync and needs to figure out what's not been ingested, the script in this PR comes in to play.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] Major new functionality has appropriate Sphinx documentation
- [X] Added an entry to release notes if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked in the description (use `Closes #` if this PR closes the issue, or some other reference, such as `See #` if it is related in some other way)
