### PR TITLE
Fix make clean for the autosummary docs

### DIFF
--- a/sphinx/Makefile
+++ b/sphinx/Makefile
@@ -49,7 +49,7 @@ help:
 
 .PHONY: clean
 clean:
-	rm -rf $(BUILDDIR)/* source/autosummary/*.rst
+	rm -rf $(BUILDDIR)/* ../docs/autosummary/*.rst
 
 .PHONY: html
 html:


### PR DESCRIPTION
#1 moved the Sphinx source from the `sphinx/source` directory to `docs` to play better with GitHub. This also means the autosummary output goes in `docs`, but the `make clean` rule wasn't updated to remove old autosummary output from the new location. This PR fixes that.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] (N/A) Major new functionality has appropriate Sphinx documentation
- [X] (N/A) Added an entry to release notes if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked in the description (use `Closes #` if this PR closes the issue, or some other reference, such as `See #` if it is related in some other way)
