### PR TITLE
Increment output quality versions when input/code interface version changes

### DIFF
--- a/dbprocessing/runMe.py
+++ b/dbprocessing/runMe.py
@@ -495,7 +495,9 @@ class runMe(object):
                                          format(self.code_id, db_code_id))
                 raise(DButils.DBError("two different codes with the same version ode_id: {0}   db_code_id: {1}".\
                                       format(self.code_id, db_code_id)))
-            self._incVersion(ver_diff)
+            # Increment output quality if code interface increments, to
+            # maintain output_interface_version; else increment what code did.
+            self._incVersion([0, 1, 0] if ver_diff[0] else ver_diff)
             return True
         else:
             return False
@@ -564,7 +566,13 @@ class runMe(object):
                 DBlogging.dblogger.debug("Found a difference between files {0} and {1} -- {2}".format(
                     parent.file_id, parent_max.file_id, df))
 
-                if df[1]:
+                if df[0]:
+                    # Interface change on input is quality change on output,
+                    # to maintain a code's consistent output_interface_version
+                    quality_diff = True
+                    DBlogging.dblogger.debug("parent: {0} had an interface difference, will reprocess child".\
+                                             format(parent.file_id))
+                elif df[1]:
                     quality_diff = True
                     DBlogging.dblogger.debug("parent: {0} had a quality difference, will reprocess child".\
                                              format(parent.file_id))

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -40,6 +40,14 @@ older databases without ``yesterday`` and ``tomorrow`` columns in the
 ``Productprocesslink`` table (`20 <https://github.com/spacepy/dbprocessing/
 issues/20>`_).
 
+Fixed :class:`~dbprocessing.runMe.runMe` to always maintain the
+``output_interface`` version specified by the code. Updates to a code's
+interface version will increment the quality version of its output (not
+the interface); updates to a file's interface version will increment the
+quality version of child files (rather than assuming children were up-to-date
+and failing to reprocess them). (`63 <https://github.com/spacepy/dbprocessing/
+pull/63>`_)
+
 Other changes
 ^^^^^^^^^^^^^
 

--- a/unit_tests/dbp_testing.py
+++ b/unit_tests/dbp_testing.py
@@ -16,6 +16,7 @@ import sys
 os.environ['DBPROCESSING_LOG_DIR'] = os.path.join(os.path.dirname(__file__),
                                                   'unittestlogs')
 
+import dbprocessing.DButils
 import dbprocessing.Version
 
 __all__ = ['AddtoDBMixin', 'add_scripts_to_path', 'testsdir']
@@ -127,6 +128,35 @@ class AddtoDBMixin(object):
             exists_on_disk=True,
         )
         return fid
+
+    def addSkeletonMission(self):
+        """Starting with empty database, add a skeleton mission
+
+        Should be called before opening a DButils instance so that
+        the mission, etc. tables can be created.
+
+        Makes one mission, one satellite, and two instruments
+
+        Assumes self.td has the test/temp directory path (str),
+        will populate self.instrument_ids for a list of instruments.
+        """
+        dbu = dbprocessing.DButils.DButils(os.path.join(
+            self.td, 'emptyDB.sqlite'))
+        mission_id = dbu.addMission(
+            'Test mission',
+            os.path.join(self.td, 'data'),
+            os.path.join(self.td, 'incoming'),
+            os.path.join(self.td, 'codes'),
+            os.path.join(self.td, 'inspectors'),
+            os.path.join(self.td, 'errors'))
+        satellite_id = dbu.addSatellite('Satellite', mission_id)
+        # Make two instruments (so can test interactions between them)
+        self.instrument_ids = [
+            dbu.addInstrument(instrument_name='Instrument {}'.format(i),
+                              satellite_id=satellite_id)
+            for i in range(1, 3)]
+        del dbu
+
 
 def add_scripts_to_path():
     """Add the script source directory to Python path

--- a/unit_tests/test_dbprocessing.py
+++ b/unit_tests/test_dbprocessing.py
@@ -29,23 +29,8 @@ class ProcessQueueTestsBase(unittest.TestCase, dbp_testing.AddtoDBMixin):
         shutil.copy2(
             os.path.join(os.path.dirname(__file__), 'emptyDB.sqlite'),
             self.td)
-        dbu = dbprocessing.DButils.DButils(os.path.join(
-            self.td, 'emptyDB.sqlite'))
         # Set up the baseline mission environment, BEFORE making processqueue
-        mission_id = dbu.addMission(
-            'Test mission',
-            os.path.join(self.td, 'data'),
-            os.path.join(self.td, 'incoming'),
-            os.path.join(self.td, 'codes'),
-            os.path.join(self.td, 'inspectors'),
-            os.path.join(self.td, 'errors'))
-        satellite_id = dbu.addSatellite('Satellite', mission_id)
-        # Make two instruments (so can test interactions between them)
-        self.instrument_ids = [
-            dbu.addInstrument(instrument_name='Instrument {}'.format(i),
-                              satellite_id=satellite_id)
-            for i in range(1, 3)]
-        del dbu
+        self.addSkeletonMission()
         self.pq = dbprocessing.dbprocessing.ProcessQueue(
             os.path.join(self.td, 'emptyDB.sqlite'))
         self.dbu = self.pq.dbu


### PR DESCRIPTION
As discussed in #62, the interface version (x in x.y.z) of a file should be set entirely by the `output_interface_version` column in the code that creates it. #62 presents four problems in versioning, two of which (3 and 4 on that list) pertain to the interface version. This PR contains two changes to fix those problems.

One (3 from #62), if a code has its interface (major) version incremented, with no other changes (including no change to `output_interface_version`), its outputs become candidates for reprocessing and the reprocessed files will have an increment to the quality version. Without this PR, this would increment the interface version, and thus no longer match `output_interface_version`.

Two (4 from #62), if a file's interface (major) version is incremented, with no other changes, its children files become candidates for reprocessing, again with an increment to the quality version. Without this PR, these files are not reprocessed. (It's actually not an infinite loop, as I originally though, runMe just thinks the file already exists in the database and is up to date.)

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] (N/A) Major new functionality has appropriate Sphinx documentation
- [X] Added an entry to release notes if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked in the description (use `Closes #` if this PR closes the issue, or some other reference, such as `See #` if it is related in some other way)
