### PR TITLE
Minimal postgresql support in dbUtils

### DIFF
--- a/dbprocessing/DButils.py
+++ b/dbprocessing/DButils.py
@@ -118,12 +118,12 @@ class DButils(object):
                        postgresql.
         :type engine: str
         """
-        if engine is None:
-            engine = 'sqlite' if os.path.isfile(os.path.expanduser(mission))\
-                     else 'postgresql'
         self.dbIsOpen = False
         if mission is None:
             raise (DBError("Must input database name to create DButils instance"))
+        if engine is None:
+            engine = 'sqlite' if os.path.isfile(os.path.expanduser(mission))\
+                     else 'postgresql'
         self.mission = mission
         # Expose the format/regex routines of DBformatter
         fmtr = DBstrings.DBformatter()
@@ -197,7 +197,7 @@ class DButils(object):
         elif engine == 'postgresql':
             db_url = postgresql_url(self.mission)
         else:
-            raise ValueError('Unknown engine {}'.format(engine))
+            raise DBError('Unknown engine {}'.format(engine))
         try:
             engineIns = sqlalchemy.create_engine(db_url, echo=echo)
             DBlogging.dblogger.info("Database Connection opened: {0}  {1}".format(str(engineIns), self.mission))

--- a/developer/functionals/postgresql/README.txt
+++ b/developer/functionals/postgresql/README.txt
@@ -1,0 +1,22 @@
+Until we have the unit tests (and automatic functional) set up to
+support either sqlite or postgresql, this procedure was used to test
+the database creation under Postgres.
+
+$ psql -U postgres
+# CREATE DATABASE dbprocessing_test;
+# \q
+(Note this basically ignores everything regarding roles, authentication, etc.)
+$ PGUSER=postgres CreateDB.py -d postgresql dbprocessing_test
+$ PGUSER=postgres printInfo.py dbprocessing_test Mission
+
+This raises an error because there are no entries in the mission
+table, but confirms that database access works.
+
+addFromConfig doesn't currently work, but once it does, can do:
+
+$ PGUSER=postgres addFromConfig.py -m dbprocessing_test functional_test/config/testDB.conf
+
+Clean up:
+$ psql -U postgres
+# DROP DATABASE dbprocessing_test;
+# \q

--- a/docs/DButils.rst
+++ b/docs/DButils.rst
@@ -26,4 +26,4 @@ DButils
 .. autosummary::
     :toctree: autosummary
 
-
+    postgresql_url

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -74,7 +74,13 @@ Create an empty sqlite database for use in dbprocessing.
 
 This is the first step in the setup of a new processing chain.
 
-.. option:: dbname The name of the database to create
+.. option:: -d <dialect>, --dialect <dialect>
+
+   sqlalchemy dialect to use, ``sqlite`` (default) or ``postgresql``
+
+.. option:: dbname
+
+   The name of the database to create
 
 dataToIncoming.py
 -----------------

--- a/scripts/CreateDB.py
+++ b/scripts/CreateDB.py
@@ -55,25 +55,6 @@ class dbprocessing_db(object):
         self.engine = engine
         self.metadata = metadata
 
-    def addMission(self, filename):
-        """utility to add a mission"""
-        self.dbu = DButils.DButils(filename)
-        self.mission = self.dbu.addMission('rbsp', os.path.join('/', 'n', 'space_data', 'cda', 'rbsp'))
-
-    def addSatellite(self):
-        """add satellite utility"""
-        self.satellite = self.dbu.addSatellite('rbspa')  # 1
-        self.satellite = self.dbu.addSatellite('rbspb')  # 2
-
-    def addInstrument(self):
-        """addInstrument utility"""
-        self.instrument = self.dbu.addInstrument('hope', 1)
-        self.instrument = self.dbu.addInstrument('hope', 2)
-        self.instrument = self.dbu.addInstrument('rept', 1)
-        self.instrument = self.dbu.addInstrument('rept', 2)
-        self.instrument = self.dbu.addInstrument('mageis', 1)
-        self.instrument = self.dbu.addInstrument('mageis', 2)
-
 
 if __name__ == "__main__":
     usage = "usage: %prog [options] filename"

--- a/scripts/addFromConfig.py
+++ b/scripts/addFromConfig.py
@@ -341,18 +341,21 @@ if __name__ == "__main__":
         # recheck the temp file
         conf = readconfig(tmpf.name)
         configCheck(conf)
-        # do all our work on a temp version of the DB, if it all works, move tmp on top of existing
-        #   if it fails just delete the tmp and do nothing
-        orig_db = options.mission
-        tmp_db = tempfile.NamedTemporaryFile(delete=False, suffix='_temp_db')
-        tmp_db.file.writelines(cfg)
-        tmp_db.close()
-        shutil.copy(orig_db, tmp_db.name)
-        options.mission = tmp_db.name
-        try:
+        if os.path.isfile(options.mission): # sqlite
+            # do all our work on a temp version of the DB, if it all works, move tmp on top of existing
+            #   if it fails just delete the tmp and do nothing
+            orig_db = options.mission
+            tmp_db = tempfile.NamedTemporaryFile(delete=False, suffix='_temp_db')
+            tmp_db.file.writelines(cfg)
+            tmp_db.close()
+            shutil.copy(orig_db, tmp_db.name)
+            options.mission = tmp_db.name
+            try:
+                addStuff(conf, options)
+                shutil.copy(tmp_db.name, orig_db)
+            finally:
+                os.remove(tmp_db.name)
+        else: # postgresql
             addStuff(conf, options)
-            shutil.copy(tmp_db.name, orig_db)
-        finally:
-            os.remove(tmp_db.name)
     finally:
         os.remove(tmpf.name)

--- a/unit_tests/test_DButils.py
+++ b/unit_tests/test_DButils.py
@@ -307,7 +307,8 @@ class DBUtilsGetTests(TestSetup):
 
     def test_openDB1(self):
         """__init__ has an exception to test"""
-        self.assertRaises(ValueError, DButils.DButils, 'i do not exist')
+        self.assertRaises(ValueError, DButils.DButils, 'i do not exist',
+                          engine='sqlite')
 
     def test_openDB2(self):
         """__init__ bad engine"""


### PR DESCRIPTION
This is a start on #14 but by no means complete. It's an attempt to get us towards working PostgreSQL without having everything perfectly in order. In particular, it still uses the magic environment variables rather than completely generalizing the database URL.

This PR gets as far as being able to create the tables in a PostgreSQL database and start addFromConfig. Unfortunately there are some aspects of the behavior in dbUtils that are relying on sqlite, in particular weak type checking. I can do some work on that later but wanted to get this up for merge first so we don't duplicate effort. This should *not* affect current working sqlite setups.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] (N/A) Major new functionality has appropriate Sphinx documentation
- [X] (N/A) Added an entry to release notes if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked in the description (use `Closes #` if this PR closes the issue, or some other reference, such as `See #` if it is related in some other way)

There's no Sphinx documentation or release notes yet since the functionality isn't completed. Similarly for testing--there's a skeleton of a functional, but ultimately the unit tests will have to be reworked to support all of this.