### PR TITLE
Fix test_DBfile when called by itself

### DIFF
--- a/unit_tests/test_DBfile.py
+++ b/unit_tests/test_DBfile.py
@@ -7,6 +7,7 @@ from distutils.dir_util import copy_tree, remove_tree
 import os
 import tempfile
 
+import dbp_testing
 from dbprocessing import DBfile
 from dbprocessing import DButils
 from dbprocessing import Diskfile
@@ -18,10 +19,10 @@ class DBfileTests(unittest.TestCase):
     def setUp(self):
         super(DBfileTests, self).setUp()
         self.tempD = tempfile.mkdtemp()
-        copy_tree(os.path.dirname(__file__) + '/../functional_test/', self.tempD)
-        copy_tree(os.path.dirname(__file__) + '/tars/', self.tempD)
+        copy_tree(os.path.join(dbp_testing.testsdir, '..', 'functional_test'), self.tempD)
+        copy_tree(os.path.join(dbp_testing.testsdir, 'tars'), self.tempD)
 
-        self.dbu = DButils.DButils(self.tempD + '/testDB.sqlite')
+        self.dbu = DButils.DButils(os.path.join(self.tempD, 'testDB.sqlite'))
         #Update the mission path to the tmp dir
         self.dbu.getEntry('Mission', 1).rootdir = self.tempD
         self.dbu.commitDB()


### PR DESCRIPTION
This is a simple fix for test_DBfile. The included tests were working when called from `test_all.py`, but not when calling `test_DBfile.py` directly. The pathing is slightly different in those two cases and, in the latter case, it couldn't find the test data. Fixed by using the `dbp_testing` helper.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] (N/A) Major new functionality has appropriate Sphinx documentation
- [X] (N/A) Added an entry to release notes if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked in the description (use `Closes #` if this PR closes the issue, or some other reference, such as `See #` if it is related in some other way)
