### PR TITLE
Update postgresql dialect name in CreateDBsabrs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,3 +96,26 @@ workflows:
      - docs:
          requires:
            - build
+
+# Schedule disables other triggers; nightly identical to main except
+# triggers and branch restriction
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 7 * * *"
+          filters:
+            branches:
+              only:
+                - master
+                - main
+    jobs:
+     - build
+     - unittest:
+         requires:
+           - build
+     - createpostgres:
+         requires:
+           - build
+     - docs:
+         requires:
+           - build

--- a/scripts/CreateDBsabrs.py
+++ b/scripts/CreateDBsabrs.py
@@ -34,7 +34,7 @@ class dbprocessing_db(object):
 	    self.createDB()
 
     def init_db(self, user, password, db, host='localhost', port=5432):
-	url = "postgres://{0}:{1}@{2}:{3}/{4}"
+	url = "postgresql://{0}:{1}@{2}:{3}/{4}"
         url = url.format(user, password, host, port, db)
         self.engine = create_engine(url, echo=False, encoding='utf-8')
         self.metadata = sqlalchemy.MetaData(bind=self.engine, reflect=True)

--- a/scripts/CreateDBsabrs.py
+++ b/scripts/CreateDBsabrs.py
@@ -37,7 +37,8 @@ class dbprocessing_db(object):
 	url = "postgresql://{0}:{1}@{2}:{3}/{4}"
         url = url.format(user, password, host, port, db)
         self.engine = create_engine(url, echo=False, encoding='utf-8')
-        self.metadata = sqlalchemy.MetaData(bind=self.engine, reflect=True)
+        self.metadata = sqlalchemy.MetaData(bind=self.engine)
+        self.metadata.reflect()
 
     def createDB(self):
         """


### PR DESCRIPTION
SQLAlchemy quite some time ago (pre-0.6.0) renamed the `postgres` dialect to `postgresql` and recently (1.4) removed the compatibility for using the old name.  `CreateDBsabrs` was using the old name, so the CI now fails. This is why #72 is failing. `CreateDBsabrs` was also using the `reflect` kwarg for the `Metadata` constructor, deprecated since 0.8.

This PR fixes the name and the constructor call and also adds a workflow running nightly to catch this kind of change in the future without waiting for a PR to be opened.

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] (N/A) Major new functionality has appropriate Sphinx documentation
- [X] (N/A) Added an entry to release notes if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked in the description (use `Closes #` if this PR closes the issue, or some other reference, such as `See #` if it is related in some other way)
