### PR TITLE
Python 3 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,11 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/python:2.7.18
+      - image: circleci/python:2.7
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+      - image: circleci/python:3.7
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -15,13 +19,19 @@ jobs:
              pip install --user sqlalchemy
              pip install --user python-dateutil
              python setup.py install --user
+             sudo apt update
+             sudo apt install python3-pip
+             pip3 install --user sqlalchemy
+             pip3 install --user python-dateutil
+             rm -rf build/
+             python3 setup.py install --user
        - persist_to_workspace:
            root: ~/.local
            paths:
              - lib # Save installed Python libraries (including dbp itself)
   unittest:
     docker:
-      - image: circleci/python:2.7.18
+      - image: circleci/python:2.7
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -32,9 +42,22 @@ jobs:
        - run:
            command: |
              python unit_tests/test_all.py -v
+  unittest3:
+    docker:
+      - image: circleci/python:3.7
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+    steps:
+       - checkout
+       - attach_workspace:
+           at: ~/.local
+       - run:
+           command: |
+             python3 unit_tests/test_all.py -v
   createpostgres:
     docker:
-      - image: circleci/python:2.7.18
+      - image: circleci/python:2.7
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -64,9 +87,41 @@ jobs:
              createdb -h localhost sndd -O root
              pip install --user psycopg2
              python scripts/CreateDBsabrs.py
+  createpostgres3:
+    docker:
+      - image: circleci/python:3.7
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+        environment:
+          DATABASE_URL: postgresql://root@localhost/circle_test?sslmode=disable
+      - image: circleci/postgres:9.6.5-alpine-ram
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+    environment:
+      POSTGRES_USER: root
+      POSTGRES_DB: circle_test
+      POSTGRES_PASSWORD: ""
+      PGPORT: 5432
+      PGUSER: root
+      PGDATABASE: sndd
+      PGPASSWORD: ""
+      PGHOST: localhost
+    steps:
+       - checkout
+       - attach_workspace:
+           at: ~/.local
+       - run:
+           command: |
+             sudo apt update
+             sudo apt install -y postgresql-client python3-pip
+             createdb -h localhost sndd -O root
+             pip3 install --user psycopg2
+             python3 scripts/CreateDBsabrs.py
   docs:
     docker:
-      - image: circleci/python:2.7.18
+      - image: circleci/python:2.7
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
@@ -93,6 +148,12 @@ workflows:
      - createpostgres:
          requires:
            - build
+     - unittest3:
+         requires:
+           - build
+     - createpostgres3:
+         requires:
+           - build
      - docs:
          requires:
            - build
@@ -114,6 +175,12 @@ workflows:
          requires:
            - build
      - createpostgres:
+         requires:
+           - build
+     - unittest3:
+         requires:
+           - build
+     - createpostgres3:
          requires:
            - build
      - docs:

--- a/dbprocessing/DBlogging.py
+++ b/dbprocessing/DBlogging.py
@@ -38,8 +38,12 @@ dblogger.setLevel(logging.INFO)
 # handler = logging.handlers.TimedRotatingFileHandler(
 #              LOG_FILENAME, maxBytes=20000000, backupCount=0) # keep them all
 ## TODO this doesn't work so hardcode the name above, so break the rotation here
+# Without explicit encoding on the handler, logging during interpreter shutdown
+# (e.g. DButils.closeDB(), from __del__) will fail.
+# https://stackoverflow.com/questions/42372981/filehandler-encoding-producing-exception
 handler = logging.handlers.TimedRotatingFileHandler(
-    LOG_FILENAME, when='midnight', interval=1, backupCount=0, utc=True)  # keep them all
+    LOG_FILENAME, when='midnight', interval=1, backupCount=0, # keep them all
+    utc=True, encoding='ascii')
 
 LEVELS = { 'debug': logging.DEBUG,
            'info': logging.INFO,
@@ -70,9 +74,11 @@ def change_logfile(logname=None):
         basename, utctoday)))
     dblogger.info("Logging file switched from {0} to {1}".format(old_filename, LOG_FILENAME))
     new_handler = logging.handlers.TimedRotatingFileHandler(
-        LOG_FILENAME, when='midnight', interval=1, backupCount=0, utc=True)  # keep them all
+        LOG_FILENAME, when='midnight', interval=1, backupCount=0, # keep them all
+        utc=True, encoding='ascii')
     new_handler.setFormatter(formatter)
     dblogger.removeHandler(handler)
+    handler.close()
     dblogger.addHandler(new_handler)
     handler = new_handler
     dblogger.info("Switching logging file from {0} to {1}".format(old_filename, LOG_FILENAME))

--- a/dbprocessing/DButils.py
+++ b/dbprocessing/DButils.py
@@ -1425,6 +1425,7 @@ class DButils(object):
             return
         try:
             self.session.close()
+            self.engine.dispose()
             self.dbIsOpen = False
             DBlogging.dblogger.info("Database connection closed")
         except DBError:

--- a/dbprocessing/DButils.py
+++ b/dbprocessing/DButils.py
@@ -501,9 +501,11 @@ class DButils(object):
     def ProcessqueueRawadd(self, fileid, version_bump=None, commit=True):
         """
         raw add file ids to the process queue
-        *** this might break things if an id is added that does not exist
-        ***   meant to be fast and used after getting the ids
-        *** IS safe against adding ids that are already in the queue
+
+        .. warning::
+           This might break things if an id is added that does not exist;
+           it's meant to be fast and used after getting the ids.
+           IS safe against adding ids that are already in the queue.
 
         Parameters
         ==========

--- a/dbprocessing/DButils.py
+++ b/dbprocessing/DButils.py
@@ -2506,7 +2506,10 @@ class DButils(object):
         Given an input product return a list of its output product ids
         """
         out_proc = self.getProcessFromInputProduct(inprod)
-        return [self.getEntry('Process', op).output_product for op in out_proc]
+        out_prod = [self.getEntry('Process', op).output_product
+                    for op in out_proc]
+        # Skip if no output product ('', null, but allow prodid of 0)
+        return [op for op in out_prod if op or op == 0]
 
     def getProductParentTree(self):
         """

--- a/dbprocessing/DButils.py
+++ b/dbprocessing/DButils.py
@@ -750,7 +750,7 @@ class DButils(object):
         """
         ans = []
         sats = self.session.query(self.Satellite).all()
-        ans = list(map(lambda x: self.getTraceback('Satellite', x.satellite_id), sats))
+        ans = [self.getTraceback('Satellite', x.satellite_id) for x in sats]
         return ans
 
     def getAllInstruments(self):
@@ -762,7 +762,7 @@ class DButils(object):
         """
         ans = []
         insts = self.session.query(self.Instrument).all()
-        ans = list(map(lambda x: self.getTraceback('Instrument', x.instrument_id), insts))
+        ans = [self.getTraceback('Instrument', x.instrument_id) for x in insts]
         return ans
 
     def getAllCodes(self, active=True):
@@ -774,7 +774,7 @@ class DButils(object):
             codes = self.session.query(self.Code).filter(and_(self.Code.newest_version, self.Code.active_code)).all()
         else:
             codes = self.session.query(self.Code).all()
-        ans = list(map(lambda x: self.getTraceback('Code', x.code_id), codes))
+        ans = [self.getTraceback('Code', x.code_id) for x in codes]
         return ans
 
     def getAllFilenames(self,

--- a/dbprocessing/DButils.py
+++ b/dbprocessing/DButils.py
@@ -695,7 +695,9 @@ class DButils(object):
 
         >>>  pnl._purgeFileFromDB('Test-one_R0_evinst-L1_20100401_v0.1.1.cdf')
         """
-        if not hasattr(filename, '__iter__'):  # if not an iterable make it a iterable
+        # if not an iterable make it a iterable
+        if isinstance(filename, str_classes) \
+           or not isinstance(filename, collections.Iterable):
             filename = [filename]
 
         for ii, f in enumerate(filename):

--- a/dbprocessing/Diskfile.py
+++ b/dbprocessing/Diskfile.py
@@ -126,11 +126,11 @@ class Diskfile(object):
         self.READ_ACCESS = os.access(self.infile, os.R_OK)
         if not self.READ_ACCESS:
             DBlogging.dblogger.debug("{0} read access denied!".format(self.infile))
-            raise(ReadError("file is not readable, does it exist? {0}".format(self.infile)))
+            raise ReadError("file is not readable, does it exist? {0}".format(self.infile))
         self.WRITE_ACCESS = os.access(self.infile, os.W_OK) | os.path.islink(self.infile)
         if not self.WRITE_ACCESS:
             DBlogging.dblogger.debug("{0} write access denied!".format(self.infile))
-            raise(WriteError("file is not writeable, won't be able to move it to proper location: {0}".format(self.infile)))
+            raise WriteError("file is not writeable, won't be able to move it to proper location: {0}".format(self.infile))
 #        DBlogging.dblogger.debug("{0} Access Checked out OK".format(self.infile))
 
 
@@ -149,7 +149,7 @@ def calcDigest(infile):
         with open(infile, 'rb') as f:
             m.update(f.read())
     except IOError:
-        raise(DigestError("File not found: {0}".format(infile)))
+        raise DigestError("File not found: {0}".format(infile))
         
     DBlogging.dblogger.debug("digest calculated: {0}, file: {1} ".format(m.hexdigest(), infile))
 

--- a/dbprocessing/Utils.py
+++ b/dbprocessing/Utils.py
@@ -131,7 +131,7 @@ def chunker(seq, size):
     :rtype: tuple
     """
 
-    return (seq[pos:pos + size] for pos in xrange(0, len(seq), size))
+    return (seq[pos:pos + size] for pos in range(0, len(seq), size))
 
 
 def unique(seq):

--- a/dbprocessing/Utils.py
+++ b/dbprocessing/Utils.py
@@ -4,10 +4,12 @@ Class to hold random utilities of use throughout this code
 """
 from __future__ import print_function
 
+
+from ast import literal_eval as make_tuple
 try:
-    import ConfigParser
-except ImportError:
-    import configparser as ConfigParser
+    import configparser
+except ImportError: # Py2
+    import ConfigParser as configparser
 import collections
 import datetime
 import os
@@ -426,11 +428,20 @@ def readconfig(config_filepath):
     :return: Dictionary of key value pairs from config files
     :rtype: dict
     """
-    cfg = ConfigParser.SafeConfigParser()
+    # "Safe" deprecated in 3.2, but still present, so version is only way
+    #  to avoid stepping on the deprecation. "Safe" preferred before 3.2
+    cfg = (configparser.SafeConfigParser if sys.version_info[:2] < (3, 2)
+           else configparser.ConfigParser)()
     cfg.read(config_filepath)
     sections = cfg.sections()
     # Read each parameter in turn
     ans = { }
     for section in sections:
         ans[section] = dict(cfg.items(section))
+        for item in ans[section]:
+            if 'input' in item:
+                if '(' in ans[section][item]:
+                    ans[section][item] = make_tuple(ans[section][item])
+                else:
+                    ans[section][item] = (ans[section][item], 0, 0)
     return ans

--- a/dbprocessing/Utils.py
+++ b/dbprocessing/Utils.py
@@ -178,7 +178,7 @@ def daterange_to_dates(daterange):
     """
 
     return [daterange[0] + datetime.timedelta(days=val) for val in
-            xrange((daterange[1] - daterange[0]).days + 1)]
+            range((daterange[1] - daterange[0]).days + 1)]
 
 
 def parseDate(inval):
@@ -223,7 +223,7 @@ def flatten(l):
     :rtype: list
     """
     for el in l:
-        if isinstance(el, collections.Iterable) and not isinstance(el, basestring):
+        if isinstance(el, collections.Iterable) and not isinstance(el, str_classes):
             for sub in flatten(el):
                 yield sub
         else:
@@ -366,7 +366,7 @@ def dirSubs(path, filename, utc_file_date, utc_start_time, version, dbu=None):
     if '{S}' in path:
         path = path.replace('{S}', utc_start_time.strftime('%S'))
     if '{VERSION}' in path:
-        if isinstance(version, (unicode, str)):
+        if isinstance(version, str_classes):
             version = Version.Version.fromString(version)
         path = path.replace('{VERSION}', '{0}'.format(str(version)))
     if '{DATE}' in path:

--- a/dbprocessing/Version.py
+++ b/dbprocessing/Version.py
@@ -83,7 +83,7 @@ class Version(object):
         Check a version to make sure it is valid, works on current object
         """
         if self.interface == 0:
-            raise (VersionError("interface_version starts at 1"))
+            raise VersionError("interface_version starts at 1")
 
     def __repr__(self):
         return 'Version: ' + self.__str__()

--- a/dbprocessing/Version.py
+++ b/dbprocessing/Version.py
@@ -92,6 +92,10 @@ class Version(object):
         return str(self.interface) + '.' + str(self.quality) + '.' + \
                str(self.revision)
 
+    def __format__(self, *args, **kwargs):
+        """Explicitly format as string"""
+        return format(str(self), *args, **kwargs)
+
     def incInterface(self):
         """Increment the interface version and reset the other two"""
         self.interface += 1

--- a/dbprocessing/dbprocessing.py
+++ b/dbprocessing/dbprocessing.py
@@ -175,7 +175,7 @@ class ProcessQueue(object):
                 self.dbu.session.commit()
             except IntegrityError as IE:
                 self.session.rollback()
-                raise (DButils.DBError(IE))
+                raise DButils.DBError(IE)
             # add to processqueue for later processing
             self.dbu.ProcessqueuePush(f_id)
             return f_id
@@ -260,7 +260,7 @@ class ProcessQueue(object):
             return None
         if len(claimed) > 1:
             DBlogging.dblogger.error("File {0} matched more than one product, there is a DB error".format(filename))
-            raise (DButils.DBError("File {0} matched more than one product, there is a DB error".format(filename)))
+            raise DButils.DBError("File {0} matched more than one product, there is a DB error".format(filename))
 
         return claimed[0]  # return the diskfile
 
@@ -334,8 +334,8 @@ class ProcessQueue(object):
                 # and give it the right name
                 files = files_out
         else:
-            raise (NotImplementedError('Not implemented yet: {0} based processing'.format(timebase)))
-            raise (ValueError('Bad timebase for product: {0}'.format(process_id)))
+            raise NotImplementedError('Not implemented yet: {0} based processing'.format(timebase))
+            raise ValueError('Bad timebase for product: {0}'.format(process_id))
         return files, input_product_id
 
     def buildChildren(self, file_id, debug=False, skip_run=False, run_procs=None):
@@ -441,7 +441,7 @@ class ProcessQueue(object):
         ##
         # not sure how to deal with having to specify a filename and handle that in the DB
         # things made here will also have to have inspectors
-        raise (NotImplementedError('Not yet implemented'))
+        raise NotImplementedError('Not yet implemented')
 
     def _reprocessBy(self,
                      startDate=None,

--- a/dbprocessing/dbprocessing.py
+++ b/dbprocessing/dbprocessing.py
@@ -236,7 +236,7 @@ class ProcessQueue(object):
             if arg is not None:
                 kwargs = strargs_to_args(arg)
                 try:
-                    df = inspect.Inspector(filename, self.dbu, product, **kwargs)
+                    df = inspect.Inspector(filename, self.dbu, product, **kwargs)()
                 except:
                     exc_type, exc_value, exc_traceback = sys.exc_info()
                     DBlogging.dblogger.error(
@@ -246,7 +246,7 @@ class ProcessQueue(object):
                     continue  # try the next inspector
             else:
                 try:
-                    df = inspect.Inspector(filename, self.dbu, product, )
+                    df = inspect.Inspector(filename, self.dbu, product, )()
                 except:
                     DBlogging.dblogger.error("File {0} inspector threw an exception".format(filename))
                     continue  # try the next inspector

--- a/dbprocessing/dbprocessing.py
+++ b/dbprocessing/dbprocessing.py
@@ -177,7 +177,7 @@ class ProcessQueue(object):
                 self.session.rollback()
                 raise (DButils.DBError(IE))
             # add to processqueue for later processing
-            self.dbu.Processqueue.push(f_id)
+            self.dbu.ProcessqueuePush(f_id)
             return f_id
         else:
             return None
@@ -467,7 +467,7 @@ class ProcessQueue(object):
                                                           instrument=instrument,
                                                           newest_version=True)]
 
-        return self.dbu.Processqueue.rawadd(f_ids, incVersion)
+        return self.dbu.ProcessqueueRawadd(f_ids, incVersion)
 
     def reprocessByCode(self, id_in, startDate=None, endDate=None, incVersion=None):
         try:

--- a/dbprocessing/inspector.py
+++ b/dbprocessing/inspector.py
@@ -36,22 +36,6 @@ from . import Diskfile
 from . import Version
 from . import DBstrings
 
-def EphemeralCallable(basetype=type):
-    def _new_caller(cls, *args, **kwargs):
-        return cls.__ephemeral_encapsulated__(*args, **kwargs)()
-    class _EphemeralMetaclass(basetype):
-        def __new__(cls, name, bases, dct):
-            encbases = tuple([b.__ephemeral_encapsulated__
-                              if hasattr(b, '__ephemeral_encapsulated__')
-                              else b for b in bases])
-            encaps = super(_EphemeralMetaclass, cls).__new__(
-                cls, '_' + name + '_ephemeral_encapsulated', encbases, dct)
-            return super(_EphemeralMetaclass, cls).__new__(
-                cls, name, bases,
-                {'__new__': _new_caller,
-                 '__ephemeral_encapsulated__': encaps})
-    return _EphemeralMetaclass
-
 
 class DefaultFields(dict):
     """Dict-like with defaults for the special fields used by DBformatter
@@ -86,7 +70,6 @@ class inspector(object):
     ABC for inspectors to be sure the user has implemented what is required
     and to provide for utility routes common to many inspectors
     """
-    __metaclass__ = EphemeralCallable(ABCMeta)
 
     def __init__(self, filename, dbu, product, **kwargs):
         """"""

--- a/dbprocessing/runMe.py
+++ b/dbprocessing/runMe.py
@@ -129,7 +129,7 @@ def _start_a_run(runme):
                                      .format(f, runme.cmdline))
         else:
             print("Could not have gotten here")
-            raise(RuntimeError("Should not have gotten here"))
+            raise RuntimeError("Should not have gotten here")
 
 
 def runner(runme_list, dbu, MAX_PROC=2, rundir=None):
@@ -226,7 +226,7 @@ def runner(runme_list, dbu, MAX_PROC=2, rundir=None):
             except IOError:
                 DBlogging.dblogger.error("Could not create the prob file, so skipped {0}"
                                             .format(os.path.basename(' '.join(runme.cmdline))))
-                #raise(IOError("Could not create the prob file, so died {0}".format(os.path.basename(' '.join(runme.cmdline)))))
+                #raise IOError("Could not create the prob file, so died {0}".format(os.path.basename(' '.join(runme.cmdline))))
                 try:
                     rm_tempdir(runme.tempdir) # delete the tempdir
                 except OSError:
@@ -271,7 +271,7 @@ def runner(runme_list, dbu, MAX_PROC=2, rundir=None):
                 print("{0} Process {1} FINISHED".format(DFP(), ' '.join(rm.cmdline)))
                 n_good += 1
             else:
-                raise(ValueError("Should not have gotten here"))
+                raise ValueError("Should not have gotten here")
 
             # execution gets here if the process finished
             del processes[p]
@@ -435,7 +435,7 @@ class runMe(object):
         attrs = ['ableToRun', 'code_id', 'extra_params', 'input_files', 'out_prod', 'pq',
                  'args', 'codepath', 'filename', 'output_version', 'process_id', 'utc_file_date']
         if not isinstance(other, runMe):
-            raise(TypeError("Cannot compare runMe with {0}".format(type(other))))
+            raise TypeError("Cannot compare runMe with {0}".format(type(other)))
         for a in attrs:
             if getattr(self, a) != getattr(other, a):
                 return False
@@ -493,8 +493,8 @@ class runMe(object):
             if ver_diff == [0,0,0]:
                 DBlogging.dblogger.error("two different codes with the same version ode_id: {0}   db_code_id: {1}".\
                                          format(self.code_id, db_code_id))
-                raise(DButils.DBError("two different codes with the same version ode_id: {0}   db_code_id: {1}".\
-                                      format(self.code_id, db_code_id)))
+                raise DButils.DBError("two different codes with the same version ode_id: {0}   db_code_id: {1}".\
+                                      format(self.code_id, db_code_id))
             # Increment output quality if code interface increments, to
             # maintain output_interface_version; else increment what code did.
             self._incVersion([0, 1, 0] if ver_diff[0] else ver_diff)
@@ -535,7 +535,7 @@ class runMe(object):
             return None
 
         DBlogging.dblogger.debug("db_file: {0} has parents: {1}".format(f_id_db,
-               map(attrgetter('file_id'), parents)))
+               list(map(attrgetter('file_id'), parents))))
 
         # if there are more input files now then we need to reprocess
         if len(self.input_files) != len(parents):

--- a/docs/inspector.rst
+++ b/docs/inspector.rst
@@ -25,4 +25,3 @@ inspector
     extract_YYYYMMDD
     extract_Version
     valid_YYYYMMDD
-    EphemeralCallable

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -26,6 +26,9 @@ format but are not in database, and symlink them to the incoming directory
 so they can be ingested (`54 <https://github.com/spacepy/dbprocessing/
 pull/54>`_).
 
+Python 3 support was added.  (`77 <https://github.com/spacepy/dbprocessing/
+pull/77>`_).
+
 Deprecations and removals
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -37,6 +37,19 @@ Clear a processing flag (lock) on a database that has crashed.
 .. option:: database The name of the database to unlock
 .. option:: message Log message to insert into the database
 
+compareDB.py
+------------
+.. program:: compareDB.py
+
+Compares two databases for having the same products, processes, codes,
+and files; matching is done by name not ID, as ID may differ. The input
+files for each file, and the codes used to make each file, are also
+compared by filename. Output is printed to the screen.
+
+.. option:: -m <dbname>, --mission <dbname>
+
+   Mission database. Specify twice, for the two missions to compare.
+
 configFromDB.py
 ---------------
 .. program:: configFromDB

--- a/scripts/CreateDB.py
+++ b/scripts/CreateDB.py
@@ -41,7 +41,7 @@ class dbprocessing_db(object):
 
         """
         if self.overwrite:
-            raise (NotImplementedError('overwrite is not yet implemented'))
+            raise NotImplementedError('overwrite is not yet implemented')
 
         # TODO move this out so that the user chooses the db type
         if self.dialect == 'sqlite':

--- a/scripts/CreateDBsabrs.py
+++ b/scripts/CreateDBsabrs.py
@@ -31,10 +31,10 @@ class dbprocessing_db(object):
         self.db_name = os.environ["PGDATABASE"]
         self.dbIsOpen = False
         if create:
-	    self.createDB()
+            self.createDB()
 
     def init_db(self, user, password, db, host='localhost', port=5432):
-	url = "postgresql://{0}:{1}@{2}:{3}/{4}"
+        url = "postgresql://{0}:{1}@{2}:{3}/{4}"
         url = url.format(user, password, host, port, db)
         self.engine = create_engine(url, echo=False, encoding='utf-8')
         self.metadata = sqlalchemy.MetaData(bind=self.engine)
@@ -172,7 +172,7 @@ class dbprocessing_db(object):
                      data_table.columns['utc_file_date'],
                      data_table.columns['utc_start_time'],
                      data_table.columns['utc_stop_time'], unique=True
-		     )
+        )
 
         data_table = schema.Table('unixtime', metadata,
                                   schema.Column('file_id', types.Integer,
@@ -190,7 +190,7 @@ class dbprocessing_db(object):
                                   schema.PrimaryKeyConstraint('source_file', 'resulting_file'),
                                   schema.CheckConstraint('source_file <> resulting_file'),
                                   # TODO this is supposed to be more general than !=
-		                  extend_existing=True)
+                                  extend_existing=True)
 
         data_table = schema.Table('code', metadata,
                                   schema.Column('code_id', types.Integer, autoincrement=True, primary_key=True,
@@ -216,7 +216,7 @@ class dbprocessing_db(object):
                                   schema.CheckConstraint('code_start_date <= code_stop_date'),
                                   schema.CheckConstraint('interface_version >= 1'),
                                   schema.CheckConstraint('output_interface_version >= 1'),
-		                  extend_existing=True
+                                  extend_existing=True
                                   )
 
         data_table = schema.Table('processqueue', metadata,
@@ -227,7 +227,7 @@ class dbprocessing_db(object):
                                   schema.Column('instrument_id', types.Integer,
                                                 schema.ForeignKey('instrument.instrument_id'), nullable=False),
                                   schema.CheckConstraint('version_bump is NULL or version_bump < 3'),
-		                  extend_existing=True
+                                  extend_existing=True
                                   )
 
         data_table = schema.Table('filecodelink', metadata,
@@ -236,7 +236,7 @@ class dbprocessing_db(object):
                                   schema.Column('source_code', types.Integer,
                                                 schema.ForeignKey('code.code_id'), nullable=False),
                                   schema.PrimaryKeyConstraint('resulting_file', 'source_code'),
-		                  extend_existing=True
+                                  extend_existing=True
                                   )
 
         data_table = schema.Table('release', metadata,
@@ -244,7 +244,7 @@ class dbprocessing_db(object):
                                                 schema.ForeignKey('file.file_id'), nullable=False, ),
                                   schema.Column('release_num', types.String(20), nullable=False),
                                   schema.PrimaryKeyConstraint('file_id', 'release_num'),
-		                  extend_existing=True
+                                  extend_existing=True
                                   )
 
         data_table = schema.Table('processpidlink', metadata,
@@ -274,7 +274,7 @@ class dbprocessing_db(object):
                                   schema.Column('hostname', types.String(100), nullable=False),
                                   # schema.PrimaryKeyConstraint('logging_id'),
                                   schema.CheckConstraint('processing_start_time < processing_end_time'),
-		                  extend_existing=True
+                                  extend_existing=True
                                   )
 
         data_table = schema.Table('logging_file', metadata,
@@ -288,7 +288,7 @@ class dbprocessing_db(object):
                                                 schema.ForeignKey('code.code_id'), nullable=False),
                                   schema.Column('comments', types.Text, nullable=True),
                                   # schema.PrimaryKeyConstraint('logging_file_id'),
-		                  extend_existing=True
+                                  extend_existing=True
                                   )
 
         data_table = schema.Table('inspector', metadata,
@@ -311,7 +311,7 @@ class dbprocessing_db(object):
                                                 schema.ForeignKey('product.product_id'), nullable=False),
                                   schema.CheckConstraint('interface_version >= 1'),
                                   schema.CheckConstraint('output_interface_version >= 1'),
-		                  extend_existing=True
+                                  extend_existing=True
                                   )
 
         # TODO move this out so that the user chooses the db type

--- a/scripts/ProcessQueue.py
+++ b/scripts/ProcessQueue.py
@@ -78,12 +78,12 @@ if __name__ == "__main__":
             # we still have an instance processing, don't start another
             pq.dbu.closeDB()
             DBlogging.dblogger.error( "There is a process running, can't start another: PID: %d" % (curr_proc))
-            raise(ProcessException("There is a process running, can't start another: PID: %d" % (curr_proc)))
+            raise ProcessException("There is a process running, can't start another: PID: %d" % (curr_proc))
         else:
             # There is a processing flag set but it died, don't start another
             pq.dbu.closeDB()
             DBlogging.dblogger.error( "There is a processing flag set but it died, don't start another" )
-            raise(ProcessException("There is a processing flag set but it died, don't start another"))
+            raise ProcessException("There is a processing flag set but it died, don't start another")
     # start logging as a lock
     pq.dbu.startLogging()
 

--- a/scripts/ProcessQueue.py
+++ b/scripts/ProcessQueue.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
 
     if options.i: # import selected
         try:
-            start_len = pq.dbu.Processqueue.len()
+            start_len = pq.dbu.ProcessqueueLen()
             print("{0} Currently {1} entries in process queue".format(DFP(), start_len))
             pq.checkIncoming(glb=options.glob) 
             if not options.dryrun:
@@ -118,21 +118,21 @@ if __name__ == "__main__":
         else:
             pq.dbu.stopLogging('Nominal Exit')
         pq.dbu.closeDB()
-        print("{0} Import finished: {1} files added".format(DFP(), pq.dbu.Processqueue.len()-start_len))
+        print("{0} Import finished: {1} files added".format(DFP(), pq.dbu.ProcessqueueLen()-start_len))
 
     if options.p: # process selected
         number_proc = 0
 
         try:
-            DBlogging.dblogger.debug("pq.dbu.Processqueue.len(): {0}".format(pq.dbu.Processqueue.len()))
+            DBlogging.dblogger.debug("pq.dbu.ProcessqueueLen(): {0}".format(pq.dbu.ProcessqueueLen()))
             # this loop does everything, both make the runMe objects and then
             #   do all the actuall running
-            while pq.dbu.Processqueue.len() > 0:
+            while pq.dbu.ProcessqueueLen() > 0:
                 # BAL 30 Mar 2017, no need to clean here as buildChildren() will clean
                 # print('{0} Cleaning Processes queue'.format(DFP()))
                 # # clean the queue
-                # pq.dbu.Processqueue.clean(options.dryrun)  # get rid of duplicates and sort
-                # if not pq.dbu.Processqueue.len():
+                # pq.dbu.ProcessqueueClean(options.dryrun)  # get rid of duplicates and sort
+                # if not pq.dbu.ProcessqueueLen():
                 #     print("{0} Process queue is empty".format(DFP()))
                 #     break
 
@@ -141,23 +141,23 @@ if __name__ == "__main__":
                 n_good  = 0
                 n_bad   = 0
                 
-                print('{0} Building commands for {1} items in the queue'.format(DFP(), pq.dbu.Processqueue.len()))
+                print('{0} Building commands for {1} items in the queue'.format(DFP(), pq.dbu.ProcessqueueLen()))
          
                 # make the cpommand lines for all the files in tehj processqueue
-                totalsize = pq.dbu.Processqueue.len()
+                totalsize = pq.dbu.ProcessqueueLen()
                 tmp_ind = 0
                 Utils.progressbar(tmp_ind, 1, totalsize, text='Command Build Progress:')
-                while pq.dbu.Processqueue.len() > 0:
+                while pq.dbu.ProcessqueueLen() > 0:
                     # do smarter pop that sorts at the db level
                     #f = (pq.dbu.session.query(pq.dbu.Processqueue.file_id)
                     #     .join((pq.dbu.File, pq.dbu.Processqueue.file_id==pq.dbu.File.file_id))
                     #     .order_by(pq.dbu.File.data_level, pq.dbu.File.utc_file_date).first())
                     #if hasattr(f, '__iter__') and len(f) == 1:
                     #    f = f[0]
-                    #pq.dbu.Processqueue.remove(f) # remove by file_id
-                    f = pq.dbu.Processqueue.pop()
-                    DBlogging.dblogger.debug("popped {0} from pq.dbu.Processqueue.get(), {1} left".format(f, pq.dbu.Processqueue.len()))
-                    #                    f = pq.dbu.Processqueue.pop() # this is empty queue safe, gives None
+                    #pq.dbu.ProcessqueueRemove(f) # remove by file_id
+                    f = pq.dbu.ProcessqueuePop()
+                    DBlogging.dblogger.debug("popped {0} from pq.dbu.ProcessqueueGet(), {1} left".format(f, pq.dbu.ProcessqueueLen()))
+                    #                    f = pq.dbu.ProcessqueuePop() # this is empty queue safe, gives None
                     #if f is None:
                     #    continue
                     pq.buildChildren(f, skip_run=options.s,

--- a/scripts/addFromConfig.py
+++ b/scripts/addFromConfig.py
@@ -95,12 +95,12 @@ def _sectionCheck(conf):
 
     # do we have any left over keys?
     if keys:
-        raise(ValueError('Section error, {0} was not understood'.format(keys[0])))
+        raise ValueError('Section error, {0} was not understood'.format(keys[0]))
 
     # check that all the required sections are there
     for req in expected[:-2]:
         if not req in conf:
-            raise (ValueError('Required section: "{0}" was not found'.format(req)))
+            raise ValueError('Required section: "{0}" was not found'.format(req))
 
 
 def _keysCheck(conf, section):
@@ -120,7 +120,7 @@ def _keysCheck(conf, section):
            or k in optional:
             continue
         if k not in conf[section]:
-            raise (ValueError('Required key: "{0}" was not found in [{1}] section'.format(k, section)))
+            raise ValueError('Required key: "{0}" was not found in [{1}] section'.format(k, section))
 
 
 def _keysRemoveExtra(conf, section):
@@ -154,10 +154,10 @@ def _keysPresentCheck(conf):
             for k2 in conf[k]:
                 if 'input' in k2:
                     if conf[k][k2][0] not in conf:
-                        raise (ValueError('Key {0} referenced in {1} was not found'.format(conf[k][k2], k)))
+                        raise ValueError('Key {0} referenced in {1} was not found'.format(conf[k][k2], k))
                 elif 'output_product' in k2:
                     if conf[k][k2] not in conf and conf[k]['output_timebase'] != "RUN":
-                        raise (ValueError('Key {0} referenced in {1} was not found'.format(conf[k][k2], k)))
+                        raise ValueError('Key {0} referenced in {1} was not found'.format(conf[k][k2], k))
 
 
 def configCheck(conf):
@@ -184,7 +184,7 @@ def _fileTest(filename):
 
     seen_twice = set([x for x in data if data.count(x) > 1]) # It's O(n^2), but it's small enough it doesn't matter
     if seen_twice:
-        raise (ValueError('Specified section(s): "{0}" is repeated!'.format(seen_twice)))
+        raise ValueError('Specified section(s): "{0}" is repeated!'.format(seen_twice))
 
 
 def addStuff(cfg, options):
@@ -213,7 +213,7 @@ def addStuff(cfg, options):
         inst_id = dbu.getInstrumentID(cfg['instrument']['instrument_name'], satellite_id)
         instrument = dbu.session.query(dbu.Instrument).get(inst_id)
         if instrument.satellite_id != satellite_id:
-            raise (ValueError())  # this means it is the same name on a different sat, need to add
+            raise ValueError()  # this means it is the same name on a different sat, need to add
         instrument_id = instrument.instrument_id
         print(
             'Found Instrument: {0} {1}'.format(instrument_id,

--- a/scripts/addFromConfig.py
+++ b/scripts/addFromConfig.py
@@ -340,7 +340,8 @@ if __name__ == "__main__":
         cfg[ii] = cfg[ii].replace('{INSTRUMENT}', INSTRUMENT)
 
     try:
-        tmpf = tempfile.NamedTemporaryFile(delete=False, suffix='_conf_file')
+        tmpf = tempfile.NamedTemporaryFile(mode='wt', delete=False,
+                                           suffix='_conf_file')
         tmpf.file.writelines(cfg)
         tmpf.close()
         # recheck the temp file
@@ -350,8 +351,8 @@ if __name__ == "__main__":
             # do all our work on a temp version of the DB, if it all works, move tmp on top of existing
             #   if it fails just delete the tmp and do nothing
             orig_db = options.mission
-            tmp_db = tempfile.NamedTemporaryFile(delete=False, suffix='_temp_db')
-            tmp_db.file.writelines(cfg)
+            tmp_db = tempfile.NamedTemporaryFile(delete=False,
+                                                 suffix='_temp_db')
             tmp_db.close()
             shutil.copy(orig_db, tmp_db.name)
             options.mission = tmp_db.name

--- a/scripts/addFromConfig.py
+++ b/scripts/addFromConfig.py
@@ -18,7 +18,10 @@
 # <- create the inst_prod link
 
 import collections
-import ConfigParser
+try:
+    import configparser
+except ImportError: # Py2
+    import ConfigParser as configparser
 import os
 import shutil
 import sys
@@ -60,7 +63,10 @@ expected_keyword['process'] = ['process_name', 'output_product',
 
 def readconfig(config_filepath):
     # Create a ConfigParser object, to read the config file
-    cfg = ConfigParser.SafeConfigParser()
+    # "Safe" deprecated in 3.2, but still present, so version is only way
+    #  to avoid stepping on the deprecation. "Safe" preferred before 3.2
+    cfg = (configparser.SafeConfigParser if sys.version_info[:2] < (3, 2)
+           else configparser.ConfigParser)()
     cfg.read(config_filepath)
     sections = cfg.sections()
     # Read each parameter in turn
@@ -81,8 +87,8 @@ def _sectionCheck(conf):
     Check the sections to be sure they are correct and readable
     """
     # check the section names that are there.
-    keys = conf.keys()
-    for key in conf.keys():
+    keys = list(conf)
+    for key in list(conf):
         # startswith allows you to supply a tuple of strings to test for
         if key.startswith(tuple(expected + ["DEFAULT"])):
             keys.remove(key)
@@ -128,7 +134,7 @@ def _keysRemoveExtra(conf, section):
         section_ex = 'product'
     else:
         section_ex = section
-    keys = conf[section].keys()
+    keys = list(conf[section])
     for k in keys:
         if k.startswith('required_input') or k.startswith('optional_input'):
             continue

--- a/scripts/clearProcessingFlag.py
+++ b/scripts/clearProcessingFlag.py
@@ -12,4 +12,5 @@ if len(sys.argv) != 3:
 if __name__ == "__main__":
     a = DButils.DButils(sys.argv[1])
     a.resetProcessingFlag(sys.argv[2])
+    a.closeDB()
     print('Database lock removed')

--- a/scripts/compareDB.py
+++ b/scripts/compareDB.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python
+
+"""Compare two databases for similarities in products, files, etc."""
+
+import argparse
+import collections
+
+import dbprocessing.DButils
+
+
+def main(mission1, mission2):
+    """Compare contents of two missions
+
+    Will open both missions and check if have same products, processes,
+    codes, and files. Output printed to screen. Comparison is based on
+    names, not IDs.
+
+    Parameters
+    ----------
+    mission1 : str
+        Name of first mission, e.g. database name or path to sqlite database
+    mission2 : str
+        Name of second mission
+    """
+    dbu1, dbu2 = None, None
+    try:
+        dbu1 = dbprocessing.DButils.DButils(mission1)
+        dbu2 = dbprocessing.DButils.DButils(mission2)
+        for t in ('product', 'process', 'code', 'file',):
+            res = check_tables(t, dbu1, dbu2)
+            if res:
+                print('\n'.join(res))
+        res = check_links(dbu1, dbu2)
+        if res:
+            print('\n'.join(res))
+    finally:
+        if dbu1 is not None:
+            dbu1.closeDB()
+        if dbu2 is not None:
+            dbu2.closeDB()
+
+
+def check_tables(table, dbu1, dbu2):
+    """Compare tables present in each database
+
+    Parameters
+    ----------
+    table : {'code', 'file', 'process', 'product'}
+        table name
+    dbu1, dbu2 : dbprocessing.DButils.DButils
+        database utils instances
+
+    Returns
+    -------
+    list
+        Any discrepancies found between databases (empty list if none)
+    """
+    out = []
+    table = table.lower()
+    assert table in ('code', 'file', 'process', 'product')
+    nameattr = '{}_name'.format(table)
+    # Get all records for this table.
+    gettername = 'getAll{}{}s'.format(table.title(),
+                                      'e' if table.endswith('s') else '')
+    if table == 'file': # There is no getAllFiles
+        entries1 = [dbu1.getEntry('File', i) for i in dbu1.getAllFileIds()]
+        entries2 = [dbu2.getEntry('File', i) for i in dbu2.getAllFileIds()]
+    else:
+        entries1 = getattr(dbu1, gettername)()
+        entries2 = getattr(dbu2, gettername)()
+    # E.g. getAllCodes returns dicts, of which only one part is the code record
+    # So recover just that part
+    if entries1 and isinstance(entries1[0], collections.Mapping):
+        entries1 = [e[table] for e in entries1]
+        entries2 = [e[table] for e in entries2]
+    # Codes also have a description not a name, and files have no _
+    for name_suffix in ('_name', '_description', 'name'):
+        nameattr = '{}{}'.format(table, name_suffix)
+        if entries1 and hasattr(entries1[0], nameattr):
+            break
+    entries1 = { getattr(p, nameattr): p for p in entries1 }
+    entries2 = { getattr(p, nameattr): p for p in entries2 }
+    # Check what's in only one database
+    names1 = set(entries1.keys())
+    names2 = set(entries2.keys())
+    for n in sorted(names1.difference(names2)):
+        out.append('{} {} is in mission1 but not mission2.'.format(
+            table.title(), n))
+    for n in sorted(names2.difference(names1)):
+        out.append('{} {} is in mission2 but not mission1.'.format(
+            table.title(), n))
+    # For every column in the record, compare across databases
+    for n in sorted(names1.intersection(names2)):
+        e1, e2 = entries1[n], entries2[n]
+        for a in list(dir(e1)):
+            if a.startswith('_'):
+                # Skip the non-public
+                continue
+            if a in (nameattr, '{}_id'.format(table)):
+                # Don't compare IDs for this table
+                continue
+            if a in ('verbose_provenance', 'shasum', 'file_create_date'):
+                # Don't compare stuff that's likely to be different
+                continue
+            if a.endswith('_id') or a in ('output_product'):
+                # Reference to another table, compare *names*
+                othertbl = 'product' if a == 'output_product' \
+                           else a.split('_')[0]
+                id1 = getattr(e1, a) #IDs into the other table
+                id2 = getattr(e2, a)
+                # Allow for not having a reference (e.g. no output product)
+                if id1 in (None, ''):
+                    n1 = ''
+                else:
+                    n1 = getattr(dbu1.getEntry(othertbl.title(), id1),
+                                 '{}_name'.format(othertbl))
+                if id2 in (None, ''):
+                    n2 = ''
+                else:
+                    n2 = getattr(dbu2.getEntry(othertbl.title(), id2),
+                                 '{}_name'.format(othertbl))
+                if n1 != n2:
+                    out.append('{} {} {} is {} in mission 1 but {} in mission 2'
+                               .format(table.title(), n, a, n1, n2))
+            elif getattr(e1, a) != getattr(e2, a):
+                # Something else. Compare values
+                out.append(
+                    '{} {} {} is {} in mission 1 but {} in mission2'.format(
+                        table.title(), n, a, getattr(e1, a), getattr(e2, a)))
+    return out
+
+
+def check_links(dbu1, dbu2):
+    """Compare file-file and file-code links across databases
+
+    Parameters
+    ----------
+    dbu1, dbu2 : dbprocessing.DButils.DButils
+        database utils instances
+
+    Returns
+    -------
+    list
+        Any discrepancies found between databases (empty list if none)
+    """
+    out = []
+    entries1 = [dbu1.getEntry('File', i) for i in dbu1.getAllFileIds()]
+    entries2 = [dbu2.getEntry('File', i) for i in dbu2.getAllFileIds()]
+    entries1 = { e.filename: e.file_id for e in entries1 }
+    entries2 = { e.filename: e.file_id for e in entries2 }
+    for f in sorted(entries1.keys()):
+        if f not in entries2: # Handled in the table check above
+            continue
+        # Check for same input files
+        infiles1 = set([e.filename for e in dbu1.getFileParents(entries1[f])])
+        infiles2 = set([e.filename for e in dbu2.getFileParents(entries2[f])])
+        for n in sorted(infiles1.difference(infiles2)):
+            out.append('{} input file {} is in mission1 but not mission2.'
+                       .format(f, n))
+        for n in sorted(infiles2.difference(infiles1)):
+            out.append('{} input file {} is in mission2 but not mission1.'
+                       .format(f, n))
+        # Now check for same input codes
+        incode1 = dbu1.session.query(dbu1.Filecodelink)\
+                       .filter_by(resulting_file=entries1[f]).all()
+        incode2 = dbu2.session.query(dbu2.Filecodelink)\
+                       .filter_by(resulting_file=entries2[f]).all()
+        if len(incode1) != len(incode2):
+            out.append('{} has {} codes in mission1 but {} in mission2.'
+                       .format(f, len(incode1), len(incode2)))
+            continue
+        if len(incode1) == 0:
+            continue
+        if len(incode1) != 1:
+            out.append('{} has {} codes, should be 0 or 1.'
+                       .format(f, len(incode1)))
+            continue
+        incode1, incode2 = incode1[0], incode2[0]
+        code1 = dbu1.getEntry('Code', incode1.source_code)
+        code2 = dbu2.getEntry('Code', incode2.source_code)
+        for attr in ('code_description', 'filename', 'relative_path',
+                     'arguments'):
+            e1, e2 = getattr(code1, attr), getattr(code2, attr)
+            if e1 != e2:
+                out.append('{} code has {} {} in mission1 but {} in mission2.'
+                           .format(f, attr, e1, e2))
+    return out
+
+
+def parse_args(argv=None):
+    """Parse arguments for this script
+
+    Parameters
+    ----------
+    argv : list
+        Argument list, default from sys.argv
+
+    Returns
+    -------
+    options : argparse.Values
+        Arguments from command line, from flags and non-flag arguments.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-m", "--mission", required=True, action='append',
+                        help="Mission databases to compare, specify twice")
+
+    options = parser.parse_args(argv)
+    if len(options.mission) != 2:
+        parser.error('Must specify two missions for comparison.')
+    return options
+
+
+if __name__ == "__main__":
+    options = parse_args()
+    main(options.mission[0], options.mission[1])

--- a/scripts/compareDB.py
+++ b/scripts/compareDB.py
@@ -78,8 +78,16 @@ def check_tables(table, dbu1, dbu2):
         nameattr = '{}{}'.format(table, name_suffix)
         if entries1 and hasattr(entries1[0], nameattr):
             break
-    entries1 = { getattr(p, nameattr): p for p in entries1 }
-    entries2 = { getattr(p, nameattr): p for p in entries2 }
+    # Code description is often not unique, so make something
+    # that might be
+    if table == 'code':
+        entries1 = { '{} {} {}'.format(
+            p.code_description, p.filename, p.arguments): p for p in entries1 }
+        entries2 = { '{} {} {}'.format(
+            p.code_description, p.filename, p.arguments): p for p in entries2 }
+    else:
+        entries1 = { getattr(p, nameattr): p for p in entries1 }
+        entries2 = { getattr(p, nameattr): p for p in entries2 }
     # Check what's in only one database
     names1 = set(entries1.keys())
     names2 = set(entries2.keys())

--- a/scripts/coveragePlot.py
+++ b/scripts/coveragePlot.py
@@ -307,6 +307,7 @@ if __name__ == "__main__":
 
 ## [settings]
 ## mission = ~/RBSP_MAGEIS.sqlite
+## outdirectory = .
 ## outformat = pdf
 ## filename_format = MagEIS_L3_Coverage_{TODAY}
 ## startdate = 20120901

--- a/scripts/coveragePlot.py
+++ b/scripts/coveragePlot.py
@@ -60,7 +60,7 @@ def _fileTest(filename):
     data = [v.strip() for v in data if v[0] == '[']
     seen_twice = rep_list(data)
     if seen_twice:
-        raise (ValueError('Specified section(s): "{0}" is repeated!'.format(seen_twice)))
+        raise ValueError('Specified section(s): "{0}" is repeated!'.format(seen_twice))
 
 
 def _processSubs(conf):
@@ -80,7 +80,7 @@ def _processSubs(conf):
                         elif 'DAYS' in sub:
                             sub_v = "**days=7**"
                         else:
-                            raise (NotImplementedError("Unsupported substitution {0} found".format(sub)))
+                            raise NotImplementedError("Unsupported substitution {0} found".format(sub))
                         conf[key][v] = conf[key][v].replace('{' + sub + '}', sub_v)
                     else:
                         break
@@ -111,7 +111,7 @@ def _processDates(conf):
                 if del_date == 'days':
                     ans[key] = date + datetime.timedelta(days=int(del_num))
                 else:
-                    raise (NotImplementedError("Unsupported substitution {0} found".format(del_date)))
+                    raise NotImplementedError("Unsupported substitution {0} found".format(del_date))
 
         try:
             conf['settings'][key] = ans[key].date()
@@ -253,9 +253,9 @@ if __name__ == "__main__":
 
             ax.set_yticks(np.arange(out[0][ind_d][0].shape[0]))
             ax.set_yticklabels(yticklabels)
-            ax.set_ylim(tb.bin_center_to_edges(range(out[0][ind_d][0].shape[0]))[0],
-                        tb.bin_center_to_edges(range(out[0][ind_d][0].shape[0]))[-1])
-            for i in tb.bin_center_to_edges(range(out[0][ind_d][0].shape[0])):
+            bin_edges = tb.bin_center_to_edges(list(range(out[0][ind_d][0].shape[0])))
+            ax.set_ylim(bin_edges[0], bin_edges[-1])
+            for i in bin_edges:
                 ax.axhline(i, color='k')
 
             steps = np.arange(out[0][ind_d][0].shape[1])

--- a/scripts/coveragePlot.py
+++ b/scripts/coveragePlot.py
@@ -9,11 +9,15 @@ Created on Fri Mar 14 10:30:27 2014
 from __future__ import division
 
 import argparse
-import ConfigParser
+try:
+    import configparser
+except ImportError: # Py2
+    import ConfigParser as configparser
 import datetime
 import fnmatch
 import os
 import subprocess
+import sys
 
 import matplotlib
 
@@ -35,7 +39,8 @@ cmap = LinearSegmentedColormap.from_list('cmap', ['r', 'g', 'y', 'grey'], N=4)
 
 def readconfig(config_filepath):
     # Create a ConfigParser object, to read the config file
-    cfg = ConfigParser.SafeConfigParser()
+    cfg = (configparser.SafeConfigParser if sys.version_info[:2] < (3, 2)
+           else configparser.ConfigParser)()
     cfg.read(config_filepath)
     sections = cfg.sections()
     # Read each parameter in turn
@@ -72,7 +77,7 @@ def _processSubs(conf):
     for key in conf:
         for v in conf[key]:
             while True:
-                if isinstance(conf[key][v], (str, unicode)):
+                if isinstance(conf[key][v], DButils.str_classes):
                     if '{' in conf[key][v] and '}' in conf[key][v]:
                         sub = conf[key][v].split('{')[1].split('}')[0]
                         if sub == 'TODAY':
@@ -142,7 +147,7 @@ def _get_yticklabels(conf, plotnum):
     """
     labels = [(v, conf['plot{0}'.format(plotnum)][v]) for v in conf['plot{0}'.format(plotnum)] if
               v.startswith('yticklabel')]
-    return zip(*sorted(labels, key=lambda x: x[0]))[1]
+    return list(zip(*sorted(labels, key=lambda x: x[0])))[1]
 
 
 def _combine_coverage(inval):
@@ -156,7 +161,7 @@ def _combine_coverage(inval):
         for ind_t, t in enumerate(inval[np_]):  # this is the date range
             out[np_].append([])
             for nprod in inval[np_][ind_t]:  # this is the product
-                out[np_][ind_t].append(np.require(zip(*ans[np_][ind_t])[1]))
+                out[np_][ind_t].append(np.require(list(zip(*ans[np_][ind_t]))[1]))
                 # [0][0] is bcease all prods have same dates and we want the first
                 out[np_][ind_t].append(ans[np_][ind_t][0][0])
     return out

--- a/scripts/coveragePlot.py
+++ b/scripts/coveragePlot.py
@@ -282,6 +282,7 @@ if __name__ == "__main__":
             conf['settings']['filename_format'] + '_{0:03d}.{1}'
             .format(ind_d, conf['settings']['outformat']))))))
         plt.savefig(outfiles[-1])
+        plt.close()
         print("Wrote: {0}".format(outfiles[-1]))
 
     comb_name = (os.path.join(conf['settings']['outdirectory'],

--- a/scripts/deleteAllDBFiles.py
+++ b/scripts/deleteAllDBFiles.py
@@ -13,7 +13,8 @@ if __name__ == "__main__":
     options = parser.parse_args()
 
     a = DButils.DButils(options.mission)
-    f = a.getAllFilenames()
+    f = a.getAllFilenames(fullPath=False)
     for ff in f:
-        a._purgeFileFromDB(ff[0])
+        a._purgeFileFromDB(ff)
     print('deleted {0} files'.format(len(f)))
+    a.closeDB()

--- a/scripts/fast_data.py
+++ b/scripts/fast_data.py
@@ -152,7 +152,7 @@ if __name__ == '__main__':
     except TypeError as err:
         parser.error("Must pass a cutoff date in form YYYY-MM-DD")
     except ValueError as err:
-        parser.error(err.message)
+        parser.error(str(err))
 
     if not (options.files or options.records):
         warnings.warn("Will not take any action without --reap-files or"

--- a/scripts/flushProcessQueue.py
+++ b/scripts/flushProcessQueue.py
@@ -12,7 +12,7 @@ if len(sys.argv) != 2:
 
 if __name__ == "__main__":
     a = DButils.DButils(sys.argv[1])
-    n_items = a.Processqueue.len()
-    a.Processqueue.flush()
+    n_items = a.ProcessqueueLen()
+    a.ProcessqueueFlush()
     print('Flushed {0} items from queue'.format(n_items))
 

--- a/scripts/htmlCoverage.py
+++ b/scripts/htmlCoverage.py
@@ -216,7 +216,7 @@ if __name__ == "__main__":
         shutil.move(filename, outname)
         os.chmod(outname, 0o664)
         Time1 = EventTimer ('Created: {0}'.format(outname), Time1) 
-
+    dbu.closeDB()
 
 
 

--- a/scripts/htmlCoverage.py
+++ b/scripts/htmlCoverage.py
@@ -124,7 +124,10 @@ def makeHTML(dbu, info, satellite, delta_days=3):
     <br>
     </body></html>
     """
-    output = tempfile.NamedTemporaryFile(delete=False, suffix='_htmlCoverage')
+    kwargs = {'delete': False, 'suffix': '_htmlCoverage', 'mode': 'w+t'}
+    if str is not bytes: # Encoding of temporary file only in python 3
+        kwargs['encoding'] = 'ascii'
+    output = tempfile.NamedTemporaryFile(**kwargs)
     output.writelines(header)
 
     output.write('<h1>{0}</h1>\n'.format(dbu.mission))

--- a/scripts/htmlCoverage.py
+++ b/scripts/htmlCoverage.py
@@ -214,7 +214,7 @@ if __name__ == "__main__":
         filename = makeHTML(dbu, info, sat, delta_days=options.deltadays)
         outname = options.outbase + '_{0}.html'.format(sat)
         shutil.move(filename, outname)
-        os.chmod(outname, 0664)
+        os.chmod(outname, 0o664)
         Time1 = EventTimer ('Created: {0}'.format(outname), Time1) 
 
 

--- a/scripts/htmlCoverage.py
+++ b/scripts/htmlCoverage.py
@@ -15,10 +15,8 @@ import stat
 import dateutil
 from sqlalchemy import func
 
-import rbsp #rbsp.mission_day_to_UTC
 
 from dbprocessing import Utils, inspector
-from rbsp import Version
 
 from dbprocessing import DButils
 
@@ -98,20 +96,20 @@ def makeHTML(dbu, info, satellite, delta_days=3):
       <meta content="text/html; charset=ISO-8859-1" http-equiv="content-type"><title>{0}</title>
         <style type="text/css">
             table, td, th
-            {
+            {{
             border:1px solid green;
             padding:3px 7px 2px 7px;
-            }
+            }}
             th
-            {
+            {{
             background-color:green;
             color:white;
-            }
+            }}
             tr.alt td
-            {
+            {{
             color:#000000;
             background-color:#EAF2D3;
-            }
+            }}
         </style>
 
     </head>
@@ -174,8 +172,7 @@ def makeHTML(dbu, info, satellite, delta_days=3):
             output.write('<tr class="alt">')
         output.write('<td>{0}</td>'.format(d.isoformat()))
         output.write('<td>{0}</td>'.format(
-            int(rbsp.UTC_to_mission_day(satellite[-1],
-                                        datetime.datetime.combine(d, datetime.time(0))))))
+            d.strftime('%Y-%j')))
 
         for p in products:
             fdates = [v.utc_file_date for v in info[satellite][p][1]]
@@ -198,8 +195,8 @@ def makeHTML(dbu, info, satellite, delta_days=3):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("-m", "--mission", type=str,
-                        help="mission to connect to", default='~ectsoc/RBSP_processing.sqlite')
+    parser.add_argument("-m", "--mission", type=str, required=True,
+                        help="mission to connect to")
     parser.add_argument("-d", "--deltadays", type=int,
                         help="days past last file to make table", default=3)
     parser.add_argument('outbase', type=str,

--- a/scripts/makeLatestSymlinks.py
+++ b/scripts/makeLatestSymlinks.py
@@ -7,7 +7,10 @@ in a given directory make symlinks to all the newest versions of files into anot
 from __future__ import print_function
 
 import argparse
-import ConfigParser
+try:
+    import configparser
+except ImportError: # Py2
+    import ConfigParser as configparser
 import datetime
 import glob
 from pprint import pprint
@@ -155,7 +158,10 @@ def readconfig(config_filepath):
     expected_items = ['sourcedir', 'destdir', 'deltadays', 'startdate',
                       'enddate', 'filter', 'linkdirs', 'outmode', 'nodate']
     # Create a ConfigParser object, to read the config file
-    cfg=ConfigParser.SafeConfigParser()
+    # "Safe" deprecated in 3.2, but still present, so version is only way
+    #  to avoid stepping on the deprecation. "Safe" preferred before 3.2
+    cfg = (configparser.SafeConfigParser if sys.version_info[:2] < (3, 2)
+           else configparser.ConfigParser)()
     cfg.read(config_filepath)
     sections = cfg.sections()
     # Read each parameter in turn
@@ -166,25 +172,25 @@ def readconfig(config_filepath):
     for k in ans:
         for ei in expected_items:
             if ei not in ans[k]:
-                raise(ValueError('Section [{0}] does not have required key "{1}"'.format(k, ei)))
+                raise ValueError('Section [{0}] does not have required key "{1}"'.format(k, ei))
     # check that we can parse the dates
     for k in ans:
         try:
             tmp = dup.parse(ans[k]['startdate'])
         except:
-            raise(ValueError('Date "{0}" in [{1}][{2}] is not valid'.format(ans[k]['startdate'], k, 'startdate',)))
+            raise ValueError('Date "{0}" in [{1}][{2}] is not valid'.format(ans[k]['startdate'], k, 'startdate',))
         try:
             tmp = dup.parse(ans[k]['enddate'])
         except:
-            raise(ValueError('Date "{0}" in [{1}][{2}] is not valid'.format(ans[k]['enddate'], k, 'enddate')))
+            raise ValueError('Date "{0}" in [{1}][{2}] is not valid'.format(ans[k]['enddate'], k, 'enddate'))
         try:
             tmp = int(ans[k]['deltadays'])
         except:
-            raise(ValueError('Invalid "{0}" in [{1}][{2}]'.format(ans[k]['deltadays'], k, 'deltadays')))
+            raise ValueError('Invalid "{0}" in [{1}][{2}]'.format(ans[k]['deltadays'], k, 'deltadays'))
         try:
             tmp = int(ans[k]['outmode'])
         except:
-            raise(ValueError('Invalid "{0}" in [{1}][{2}]'.format(ans[k]['outmode'], k, 'outmode')))
+            raise ValueError('Invalid "{0}" in [{1}][{2}]'.format(ans[k]['outmode'], k, 'outmode'))
     for k in ans:
         ans[k]['sourcedir'] = os.path.abspath(os.path.expanduser(os.path.expandvars(ans[k]['sourcedir'])))
         ans[k]['destdir']   = os.path.abspath(os.path.expanduser(os.path.expandvars(ans[k]['destdir'])))

--- a/scripts/makeLatestSymlinks.py
+++ b/scripts/makeLatestSymlinks.py
@@ -264,3 +264,23 @@ if __name__ == '__main__':
             #if options.verbose: print files_out
             make_symlinks(files, files_out, config[sec]['destdir'], config[sec]['linkdirs'], config[sec]['outmode'], options)
 
+# Example configuration file, copy and remove leading "##" to use
+##[isois]
+### Directory containing the data files
+##sourcedir = ~/dbp_py3/data/ISOIS/level1/
+### Directory to make the symlinks in
+##destdir = ~/tmp/
+### First date to link
+##startdate = 2010-01-01
+### Last date to link
+##enddate = 2021-01-01
+### Number of days before present not to link (e.g. to keep internal-only)
+##deltadays = 60
+### glob for files to match
+##filter = psp_isois_l1-sc-hk_*.cdf
+### Link directories as well as files
+##linkdirs = True
+### Mode to use when making output directory
+##outmode = 775
+### Do not limit based on date (i.e., ignore date options; they're still required)
+##nodate = False

--- a/scripts/makeLatestSymlinks.py
+++ b/scripts/makeLatestSymlinks.py
@@ -23,6 +23,7 @@ import warnings
 from dateutil import parser as dup
 
 from dbprocessing import inspector
+import dbprocessing.Utils
 
 
 ################################################################
@@ -157,17 +158,8 @@ def delete_unneeded(files, files_out, options):
 def readconfig(config_filepath):
     expected_items = ['sourcedir', 'destdir', 'deltadays', 'startdate',
                       'enddate', 'filter', 'linkdirs', 'outmode', 'nodate']
-    # Create a ConfigParser object, to read the config file
-    # "Safe" deprecated in 3.2, but still present, so version is only way
-    #  to avoid stepping on the deprecation. "Safe" preferred before 3.2
-    cfg = (configparser.SafeConfigParser if sys.version_info[:2] < (3, 2)
-           else configparser.ConfigParser)()
-    cfg.read(config_filepath)
-    sections = cfg.sections()
     # Read each parameter in turn
-    ans = {}
-    for section in sections:
-        ans[section] = dict(cfg.items(section))
+    ans = dbprocessing.Utils.readconfig(config_filepath)
     # make sure that for each section the reqiured items are present
     for k in ans:
         for ei in expected_items:

--- a/scripts/makeLatestSymlinks.py
+++ b/scripts/makeLatestSymlinks.py
@@ -7,10 +7,7 @@ in a given directory make symlinks to all the newest versions of files into anot
 from __future__ import print_function
 
 import argparse
-try:
-    import configparser
-except ImportError: # Py2
-    import ConfigParser as configparser
+import collections
 import datetime
 import glob
 from pprint import pprint
@@ -24,6 +21,7 @@ from dateutil import parser as dup
 
 from dbprocessing import inspector
 import dbprocessing.Utils
+import dbprocessing.DButils
 
 
 ################################################################
@@ -66,8 +64,9 @@ def cull_to_newest(files, options=None):
     ans = []
     # make a set of all the file bases
     tmp = [getBaseVersion(f) for f in files]
-    bases = zip(*tmp)[0]
-    versions = zip(*tmp)[1]
+    tmp = list(zip(*tmp))
+    bases = tmp[0]
+    versions = tmp[1]
     uniq_bases = list(set(bases))
     while uniq_bases:
         val = uniq_bases.pop(0)
@@ -115,9 +114,11 @@ def make_symlinks(files, files_out, outdir, linkdirs, mode, options):
     """
     for all the files make symlinks into outdir
     """
-    if not hasattr(files, '__iter__'):
+    if isinstance(files, dbprocessing.DButils.str_classes) \
+           or not isinstance(files, collections.Iterable):
         files = [files]
-    if not hasattr(files_out, '__iter__'):
+    if isinstance(files_out, dbprocessing.DButils.str_classes) \
+           or not isinstance(files_out, collections.Iterable):
         files_out = [files_out]
     # if files_out then cull the files to get rid of the ones
     for f in files:

--- a/scripts/missingFiles.py
+++ b/scripts/missingFiles.py
@@ -11,6 +11,7 @@ import datetime
 import fnmatch
 import os
 import subprocess
+import sys
 
 from dateutil import parser as dup
 
@@ -50,7 +51,10 @@ if __name__ == "__main__":
     tree = dbu.getProductParentTree()
     for t1 in tree:
         for t2 in t1[1]:
-            cmd = [ os.path.expanduser('~/dbUtils/missingFilesByProduct.py'),
+            cmd = [
+                sys.executable,
+                os.path.join(os.path.dirname(__file__),
+                             'missingFilesByProduct.py'),
                 '-m', options.mission,
                 '-s', startDate.date().isoformat(),
                 '-e', endDate.date().isoformat(),

--- a/scripts/missingFiles.py
+++ b/scripts/missingFiles.py
@@ -49,6 +49,7 @@ if __name__ == "__main__":
 
     # get the product tree:
     tree = dbu.getProductParentTree()
+    del dbu
     for t1 in tree:
         for t2 in t1[1]:
             cmd = [

--- a/scripts/missingFilesByProduct.py
+++ b/scripts/missingFilesByProduct.py
@@ -104,7 +104,7 @@ if __name__ == "__main__":
         files = dbu.session.query(dbu.File.file_id).filter_by(product_id=options.parent).filter(dbu.File.utc_file_date.in_(missing_dates)).all()
         if not len(files):
             sys.exit(0)
-        files = map(itemgetter(0), files)
+        files = list(map(itemgetter(0), files))
         added = dbu.ProcessqueuePush(files)
         print("   -- Added {0} files to be reprocessed for product {1}".format(len(added), options.parent))
         DBlogging.dblogger.info('Added {0} files to be reprocessed for product {1}'.format(len(added), options.parent))

--- a/scripts/missingFilesByProduct.py
+++ b/scripts/missingFilesByProduct.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
         if not len(files):
             sys.exit(0)
         files = map(itemgetter(0), files)
-        added = dbu.Processqueue.push(files)
+        added = dbu.ProcessqueuePush(files)
         print("   -- Added {0} files to be reprocessed for product {1}".format(len(added), options.parent))
         DBlogging.dblogger.info('Added {0} files to be reprocessed for product {1}'.format(len(added), options.parent))
 

--- a/scripts/missingFilesByProduct.py
+++ b/scripts/missingFilesByProduct.py
@@ -43,7 +43,6 @@ if __name__ == "__main__":
 
     
     options = parser.parse_args()
-    print(options)
 
     if options.startDate is not None:
         startDate = dup.parse(options.startDate)
@@ -91,6 +90,7 @@ if __name__ == "__main__":
             missing_dates.append(d)
     if not missing_dates:
         print("No missing files")
+        del dbu
         sys.exit(0)
        
     print("Missing files for product {0} for these dates:".format(product_id))
@@ -102,10 +102,8 @@ if __name__ == "__main__":
             parser.error("Cannot process without a parent product id specified")
         # do a custom query here to get all the file ids in one sweep
         files = dbu.session.query(dbu.File.file_id).filter_by(product_id=options.parent).filter(dbu.File.utc_file_date.in_(missing_dates)).all()
-        if not len(files):
-            sys.exit(0)
         files = list(map(itemgetter(0), files))
         added = dbu.ProcessqueuePush(files)
         print("   -- Added {0} files to be reprocessed for product {1}".format(len(added), options.parent))
         DBlogging.dblogger.info('Added {0} files to be reprocessed for product {1}'.format(len(added), options.parent))
-
+    del dbu

--- a/scripts/newestVersionProblemFinder.py
+++ b/scripts/newestVersionProblemFinder.py
@@ -153,3 +153,4 @@ if __name__ == "__main__":
             for f2 in files2:
                 if f.file_create_date < f2.file_create_date:
                     print('{0} is the "Newest Version", however was created after {1}'.format(f.filename, f2.filename))
+    del dbu

--- a/scripts/possibleProblemDates.py
+++ b/scripts/possibleProblemDates.py
@@ -145,12 +145,12 @@ if __name__ == "__main__":
                 # we still have an instance processing, don't start another
                 dbu.closeDB()
                 DBlogging.dblogger.error( "There is a process running, can't start another: PID: %d" % (curr_proc))
-                raise(ProcessException("There is a process running, can't start another: PID: %d" % (curr_proc)))
+                raise ProcessException("There is a process running, can't start another: PID: %d" % (curr_proc))
             else:
                 # There is a processing flag set but it died, don't start another
                 dbu.closeDB()
                 DBlogging.dblogger.error( "There is a processing flag set but it died, don't start another" )
-                raise(ProcessException("There is a processing flag set but it died, don't start another"))
+                raise ProcessException("There is a processing flag set but it died, don't start another")
         
     print("Running noNewestVersion()")
     noNewestVersion(dbu, options.fix)

--- a/scripts/possibleProblemDates.py
+++ b/scripts/possibleProblemDates.py
@@ -160,4 +160,4 @@ if __name__ == "__main__":
     missingInstrumentproductlink(dbu, options.fix)
     print("Running suspiciousDateRanges()")
     suspiciousDateRanges(dbu, options.fix)
-    
+    del dbu

--- a/scripts/printInfo.py
+++ b/scripts/printInfo.py
@@ -167,7 +167,7 @@ if __name__ == '__main__':
                 print("{0:6} {1:4} {2:80} {3:40} {4:6}".format(
                     f.file_id, options.product,
                     os.path.join(filepath, f.filename), f.filename,
-                    f.newest_version))
+                    getattr(f, 'newest_version', 'N/A')))
             
         else:
             print("No files found for product {0} in date range".format(options.product))

--- a/scripts/printInfo.py
+++ b/scripts/printInfo.py
@@ -129,6 +129,7 @@ if __name__ == '__main__':
 
     elif field == 'File':
         if options.product is None:
+            dbu.closeDB()
             parser.error("To print File info a product_id is required via -p,--product")
 
         options.product = dbu.getProductID(options.product) # make sure the p_id is here or change name to p_id

--- a/scripts/printInfo.py
+++ b/scripts/printInfo.py
@@ -164,13 +164,10 @@ if __name__ == '__main__':
             filepath = os.path.dirname(dbu.getFileFullPath(files[0].file_id))
             print("{0:6} {1:4} {2:80} {3:40} {4:6}".format('f_id', 'p_id', 'full path', 'filename', 'newest'))
             for f in files:
-                print("{0:6} {1:4} {2:80} {3:40} {4:6}".format(f.file_id,
-                                                                options.product,
-                                                                os.path.join(filepath, f.filename),
-                                                                f.filename,
-                                                                f.newest_version))
-                
-
+                print("{0:6} {1:4} {2:80} {3:40} {4:6}".format(
+                    f.file_id, options.product,
+                    os.path.join(filepath, f.filename), f.filename,
+                    f.newest_version))
             
         else:
             print("No files found for product {0} in date range".format(options.product))

--- a/scripts/printInfo.py
+++ b/scripts/printInfo.py
@@ -178,7 +178,7 @@ if __name__ == '__main__':
         
     else:
         dbu.closeDB()
-        raise(NotImplementedError('Attr: "{0}" not yet implemented'.format(field) ))
+        raise NotImplementedError('Attr: "{0}" not yet implemented'.format(field) )
 
 
     dbu.closeDB()

--- a/scripts/printProcessQueue.py
+++ b/scripts/printProcessQueue.py
@@ -91,3 +91,4 @@ if __name__ == '__main__':
         output = open(options.output, 'w')
         output.write(out)
         output.close()
+    del dbu

--- a/scripts/printProcessQueue.py
+++ b/scripts/printProcessQueue.py
@@ -75,7 +75,7 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     dbu = DButils.DButils(options.database)
-    items = dbu.Processqueue.getAll()
+    items = dbu.ProcessqueueGetAll()
     traceback = []
     for v in items:
         traceback.append(dbu.getTraceback('File', v))

--- a/scripts/reprocessByCode.py
+++ b/scripts/reprocessByCode.py
@@ -54,7 +54,6 @@ if __name__ == "__main__":
         parser.error("invalid force option [0,1,2]")
     num = db.reprocessByCode(options.code, startDate=startDate, endDate=endDate, incVersion=options.force)
 
+    del db
     print('Added {0} files to be reprocessed for code {1}'.format(num, options.code))
     DBlogging.dblogger.info('Added {0} files to be reprocessed for code {1}'.format(num, options.code))
-
-

--- a/scripts/reprocessByDate.py
+++ b/scripts/reprocessByDate.py
@@ -43,6 +43,7 @@ if __name__ == "__main__":
     print(startDate, endDate)
 
     num = db.reprocessByDate(startDate=startDate, endDate=endDate, incVersion=options.force, level=options.level)
+    del db
     if num is None:
         num = 0
     print('Added {0} files to be reprocessed'.format(num))

--- a/scripts/reprocessByInstrument.py
+++ b/scripts/reprocessByInstrument.py
@@ -51,6 +51,7 @@ if __name__ == "__main__":
                                    startDate=startDate, endDate=endDate,
                                    incVersion=options.force)
 
+    del db
     print('Added {0} files to be reprocessed for instrument {1}'.format(num, options.instrument))
     DBlogging.dblogger.info('Added {0} files to be reprocessed for instrument {1}'.format(num, options.instrument))
 

--- a/scripts/reprocessByInstrument.py
+++ b/scripts/reprocessByInstrument.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
                                    startDate=startDate, endDate=endDate,
                                    incVersion=options.force)
 
-    print('Added {0} files to be reprocessed for product {1}'.format(num, options.instrument))
-    DBlogging.dblogger.info('Added {0} files to be reprocessed for product {1}'.format(num, options.instrument))
+    print('Added {0} files to be reprocessed for instrument {1}'.format(num, options.instrument))
+    DBlogging.dblogger.info('Added {0} files to be reprocessed for instrument {1}'.format(num, options.instrument))
 
 

--- a/scripts/reprocessByProduct.py
+++ b/scripts/reprocessByProduct.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
     if options.force not in [None, 0, 1, 2]:
         parser.error("invalid force option [0,1,2]")
 
-    if startDate > endDate:
+    if startDate is not None and endDate is not None and startDate > endDate:
         parser.error("startDate > endDate, nothing will be added")
 
         

--- a/scripts/reprocessByProduct.py
+++ b/scripts/reprocessByProduct.py
@@ -67,5 +67,5 @@ if __name__ == "__main__":
             num = 0
         print('Added {0} files to be reprocessed for product {1}'.format(num, prod))
         DBlogging.dblogger.info('Added {0} files to be reprocessed for product {1}'.format(num, prod))
-
+    del db
 

--- a/scripts/scrubber.py
+++ b/scripts/scrubber.py
@@ -8,11 +8,14 @@ class scrubber(object):
     def __init__(self, mission):
         self.dbu = DButils.DButils(mission)
 
+    def __del__(self):
+        del self.dbu
+
     def parents_are_newest(self):
         n = self.dbu.getAllFileIds(newest_version=True)
 
         xp = self.dbu.session.query(self.dbu.Filefilelink.source_file).filter(self.dbu.Filefilelink.resulting_file.in_(n)).all()
-        np = set(zip(*xp)[0])
+        np = set(list(zip(*xp))[0])
 
         if np.issubset(n):
             print("All parents of newest are newest")
@@ -44,3 +47,4 @@ if __name__ == '__main__':
     scrubber = scrubber(options.mission)
     scrubber.parents_are_newest()
     scrubber.version_number_check()
+    del scrubber

--- a/scripts/testInspector.py
+++ b/scripts/testInspector.py
@@ -32,3 +32,5 @@ if __name__ == '__main__':
     else:
         df = inspect.Inspector(options.file, dbu, options.product, )()
     print(df)
+    dbu.closeDB()
+    del dbu

--- a/scripts/testInspector.py
+++ b/scripts/testInspector.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
 
     if options.args:
         kwargs = strargs_to_args(options.args)
-        df = inspect.Inspector(options.file, dbu, options.product, **kwargs)
+        df = inspect.Inspector(options.file, dbu, options.product, **kwargs)()
     else:
-        df = inspect.Inspector(options.file, dbu, options.product, )
+        df = inspect.Inspector(options.file, dbu, options.product, )()
     print(df)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ scripts = ('scripts/addFromConfig.py', 'scripts/missingFilesByProduct.py',
            'scripts/htmlCoverage.py', 'scripts/updateSHAsum.py',
            'scripts/makeLatestSymlinks.py', 'scripts/testInspector.py',
            'scripts/replaceArgsWithRootdir.py', 'scripts/printRequired.py',
-           'scripts/changeProductDir.py')
+           'scripts/changeProductDir.py', 'scripts/compareDB.py')
 
 setup(name='dbprocessing',
       version='0.0',

--- a/unit_tests/inspector/rot13_L1_dlevel.py
+++ b/unit_tests/inspector/rot13_L1_dlevel.py
@@ -5,18 +5,18 @@ import re
 import datetime
 
 class Inspector(inspector.inspector):
-	code_name = "rot13_L1_dlevel.py"
+    code_name = "rot13_L1_dlevel.py"
 
-	def inspect(self, kwargs):
-		m = re.match(r'testDB_(\d{3}).*\.raw$', self.basename)
-		if not m:
-			return None
+    def inspect(self, kwargs):
+        m = re.match(r'testDB_(\d{3}).*\.raw$', self.basename)
+        if not m:
+            return None
 
-		self.diskfile.params['utc_start_time'] = datetime.datetime(2016, 1, 1) + datetime.timedelta(days=int(m.group(1)))
-		self.diskfile.params['utc_stop_time'] = self.diskfile.params['utc_start_time'] + datetime.timedelta(days=1)
-		self.diskfile.params['utc_file_date'] = self.diskfile.params['utc_start_time'].date()
-		self.diskfile.params['version'] = Version.Version(1, 0, 0)
-		self.diskfile.params['process_keywords'] = 'nnn=' + m.group(1)
-                # Setting data_level isn't allowed
-                self.diskfile.params['data_level'] = 2.0
-		return True
+        self.diskfile.params['utc_start_time'] = datetime.datetime(2016, 1, 1) + datetime.timedelta(days=int(m.group(1)))
+        self.diskfile.params['utc_stop_time'] = self.diskfile.params['utc_start_time'] + datetime.timedelta(days=1)
+        self.diskfile.params['utc_file_date'] = self.diskfile.params['utc_start_time'].date()
+        self.diskfile.params['version'] = Version.Version(1, 0, 0)
+        self.diskfile.params['process_keywords'] = 'nnn=' + m.group(1)
+        # Setting data_level isn't allowed
+        self.diskfile.params['data_level'] = 2.0
+        return True

--- a/unit_tests/test_DBstrings.py
+++ b/unit_tests/test_DBstrings.py
@@ -95,14 +95,14 @@ class DBFormatterTests(unittest.TestCase):
     def testHopeRegressExpandDatetime(self):
         """Check on the datetime expansion for a simple HOPE regression"""
         fmtstring = 'rbspa_ect-hope-hk-L05_0095_v{VERSION}.cdf'
-        fmtkeywords = {'INSTRUMENT': u'hope', 'SATELLITE': u'rbspa',
-                       'VERSION': '2.0.0', 'PRODUCT': u'rbsp_ect-hope-hk-L05',
+        fmtkeywords = {'INSTRUMENT': 'hope', 'SATELLITE': 'rbspa',
+                       'VERSION': '2.0.0', 'PRODUCT': 'rbsp_ect-hope-hk-L05',
                        'datetime': datetime.date(2012, 12, 2)}
         self.fmtr.expand_datetime(fmtkeywords)
         self.assertEqual({'DATE': '20121202',
-                          'INSTRUMENT': u'hope',
-                          'PRODUCT': u'rbsp_ect-hope-hk-L05',
-                          'SATELLITE': u'rbspa',
+                          'INSTRUMENT': 'hope',
+                          'PRODUCT': 'rbsp_ect-hope-hk-L05',
+                          'SATELLITE': 'rbspa',
                           'VERSION': '2.0.0',
                           'Y': 2012,
                           'b': 'Dec',
@@ -124,20 +124,20 @@ class DBFormatterTests(unittest.TestCase):
         #each tuple of (format string, kwargs dict)
         inputs = [
             ('rbspa_ect-hope-hk-L05_0095_v{VERSION}.cdf',
-             {'INSTRUMENT': u'hope', 'SATELLITE': u'rbspa',
-              'VERSION': '2.0.0', 'PRODUCT': u'rbsp_ect-hope-hk-L05',
+             {'INSTRUMENT': 'hope', 'SATELLITE': 'rbspa',
+              'VERSION': '2.0.0', 'PRODUCT': 'rbsp_ect-hope-hk-L05',
               'datetime': datetime.date(2012, 12, 2)}),
             ('rbspa_ect-hope-sci-L05_0091_v{VERSION}.cdf',
-             {'INSTRUMENT': u'hope', 'SATELLITE': u'rbspa',
-              'VERSION': '2.0.0', 'PRODUCT': u'rbsp_ect-hope-sci-L05',
+             {'INSTRUMENT': 'hope', 'SATELLITE': 'rbspa',
+              'VERSION': '2.0.0', 'PRODUCT': 'rbsp_ect-hope-sci-L05',
               'datetime': datetime.date(2012, 11, 28)}),
             ('rbspa_ect-hope-hk-L1_{DATE}_v{VERSION}.cdf',
-             {'INSTRUMENT': u'hope', 'SATELLITE': u'rbspa',
-              'VERSION': '2.0.0', 'PRODUCT': u'rbsp_ect-hope-hk-L1',
+             {'INSTRUMENT': 'hope', 'SATELLITE': 'rbspa',
+              'VERSION': '2.0.0', 'PRODUCT': 'rbsp_ect-hope-hk-L1',
               'datetime': datetime.date(2012, 10, 3)}),
             ('rbspa_ect-hope-sci-L1_{DATE}_v{VERSION}.cdf',
-             {'INSTRUMENT': u'hope', 'SATELLITE': u'rbspa',
-              'VERSION': '2.0.0', 'PRODUCT': u'rbsp_ect-hope-sci-L1',
+             {'INSTRUMENT': 'hope', 'SATELLITE': 'rbspa',
+              'VERSION': '2.0.0', 'PRODUCT': 'rbsp_ect-hope-sci-L1',
               'datetime': datetime.date(2012, 10, 3)}),
             ]
         #output string

--- a/unit_tests/test_DButils.py
+++ b/unit_tests/test_DButils.py
@@ -92,28 +92,28 @@ class DBUtilsOtherTests(TestSetup):
         ans = set([v.filename for v in self.dbu.getFilesByProduct(13, newest_version=True)])
         self.assertEqual(len(ans), 22)
         newest_files = set([
-                         u'ect_rbspa_0220_377_02.ptp.gz',
-                         u'ect_rbspa_0221_377_04.ptp.gz',
-                         u'ect_rbspa_0370_377_06.ptp.gz',
-                         u'ect_rbspa_0371_377_03.ptp.gz',
-                         u'ect_rbspa_0372_377_03.ptp.gz',
-                         u'ect_rbspa_0373_377_04.ptp.gz',
-                         u'ect_rbspa_0374_377_02.ptp.gz',
-                         u'ect_rbspa_0375_377_03.ptp.gz',
-                         u'ect_rbspa_0376_377_07.ptp.gz',
-                         u'ect_rbspa_0377_377_01.ptp.gz',
-                         u'ect_rbspa_0378_377_03.ptp.gz',
-                         u'ect_rbspa_0379_377_04.ptp.gz',
-                         u'ect_rbspa_0380_377_02.ptp.gz',
-                         u'ect_rbspa_0381_377_02.ptp.gz',
-                         u'ect_rbspa_0382_377_07.ptp.gz',
-                         u'ect_rbspa_0383_377_04.ptp.gz',
-                         u'ect_rbspa_0384_377_02.ptp.gz',
-                         u'ect_rbspa_0385_377_03.ptp.gz',
-                         u'ect_rbspa_0386_377_03.ptp.gz',
-                         u'ect_rbspa_0387_377_02.ptp.gz',
-                         u'ect_rbspa_0388_377_03.ptp.gz',
-                         u'ect_rbspa_0389_377_05.ptp.gz'])
+                         'ect_rbspa_0220_377_02.ptp.gz',
+                         'ect_rbspa_0221_377_04.ptp.gz',
+                         'ect_rbspa_0370_377_06.ptp.gz',
+                         'ect_rbspa_0371_377_03.ptp.gz',
+                         'ect_rbspa_0372_377_03.ptp.gz',
+                         'ect_rbspa_0373_377_04.ptp.gz',
+                         'ect_rbspa_0374_377_02.ptp.gz',
+                         'ect_rbspa_0375_377_03.ptp.gz',
+                         'ect_rbspa_0376_377_07.ptp.gz',
+                         'ect_rbspa_0377_377_01.ptp.gz',
+                         'ect_rbspa_0378_377_03.ptp.gz',
+                         'ect_rbspa_0379_377_04.ptp.gz',
+                         'ect_rbspa_0380_377_02.ptp.gz',
+                         'ect_rbspa_0381_377_02.ptp.gz',
+                         'ect_rbspa_0382_377_07.ptp.gz',
+                         'ect_rbspa_0383_377_04.ptp.gz',
+                         'ect_rbspa_0384_377_02.ptp.gz',
+                         'ect_rbspa_0385_377_03.ptp.gz',
+                         'ect_rbspa_0386_377_03.ptp.gz',
+                         'ect_rbspa_0387_377_02.ptp.gz',
+                         'ect_rbspa_0388_377_03.ptp.gz',
+                         'ect_rbspa_0389_377_05.ptp.gz'])
         self.assertEqual(ans, newest_files)
 
     def test_checkIncoming(self):
@@ -346,7 +346,11 @@ class DBUtilsGetTests(TestSetup):
         ans = self.dbu.getAllSatellites()
         # check that this is what we expect
         self.assertEqual(2, len(ans))
-        self.assertEqual([('satellite', 'satellite'), ('mission', 'mission')], zip(*ans))
+        # Checking keys
+        self.assertEqual(
+            sorted([('satellite', 'satellite'), ('mission', 'mission')]),
+            sorted(list(zip(*ans))))
+        # And for the same contents
         self.assertEqual(ans[0]['mission'], ans[1]['mission'])
         self.assertEqual(ans[0]['satellite'].satellite_name[:-1],
                          ans[1]['satellite'].satellite_name[:-1])
@@ -356,9 +360,13 @@ class DBUtilsGetTests(TestSetup):
         ans = self.dbu.getAllInstruments()
         # check that this is what we expect
         self.assertEqual(2, len(ans))
-        self.assertEqual([('instrument', 'instrument'),
-                          ('satellite', 'satellite'),
-                          ('mission', 'mission')], zip(*ans))
+        # Expected keys...
+        self.assertEqual(
+            sorted([('instrument', 'instrument'),
+                    ('satellite', 'satellite'),
+                    ('mission', 'mission')]),
+            sorted(zip(*ans)))
+        # ...and matching values
         self.assertEqual(ans[0]['mission'], ans[1]['mission'])
         self.assertEqual(ans[0]['satellite'].satellite_name[:-1],
                          ans[1]['satellite'].satellite_name[:-1])
@@ -369,7 +377,7 @@ class DBUtilsGetTests(TestSetup):
         """getAllFileIds"""
         files = self.dbu.getAllFileIds()
         self.assertEqual(6681, len(files))
-        self.assertEqual(range(1, 6682), sorted(files))
+        self.assertEqual(list(range(1, 6682)), sorted(files))
 
     def test_getAllFileIds2(self):
         """getAllFileIds"""
@@ -381,7 +389,7 @@ class DBUtilsGetTests(TestSetup):
         """getAllFileIds"""
         files = self.dbu.getAllFileIds(limit=10)
         self.assertEqual(10, len(files))
-        self.assertEqual(range(1, 11), sorted(files))
+        self.assertEqual(list(range(1, 11)), sorted(files))
 
     def test_getAllFileIds2_limit(self):
         """getAllFileIds"""
@@ -420,14 +428,14 @@ class DBUtilsGetTests(TestSetup):
 
     def test_getFileFullPath(self):
         """getFileFullPath"""
-        self.assertEqual(u'/n/space_data/cda/rbsp/MagEphem/predicted/b/rbspb_pre_MagEphem_OP77Q_20130909_v1.0.0.txt',
+        self.assertEqual('/n/space_data/cda/rbsp/MagEphem/predicted/b/rbspb_pre_MagEphem_OP77Q_20130909_v1.0.0.txt',
                          self.dbu.getFileFullPath(1))
-        self.assertEqual(u'/n/space_data/cda/rbsp/MagEphem/predicted/b/rbspb_pre_MagEphem_OP77Q_20130909_v1.0.0.txt',
+        self.assertEqual('/n/space_data/cda/rbsp/MagEphem/predicted/b/rbspb_pre_MagEphem_OP77Q_20130909_v1.0.0.txt',
                          self.dbu.getFileFullPath('rbspb_pre_MagEphem_OP77Q_20130909_v1.0.0.txt'))
 
-        self.assertEqual(u'/n/space_data/cda/rbsp/rbspb/mageis_vc/level0/ect_rbspb_0377_364_02.ptp.gz',
+        self.assertEqual('/n/space_data/cda/rbsp/rbspb/mageis_vc/level0/ect_rbspb_0377_364_02.ptp.gz',
                          self.dbu.getFileFullPath(100))
-        self.assertEqual(u'/n/space_data/cda/rbsp/rbspb/mageis_vc/level0/ect_rbspb_0377_364_02.ptp.gz',
+        self.assertEqual('/n/space_data/cda/rbsp/rbspb/mageis_vc/level0/ect_rbspb_0377_364_02.ptp.gz',
                          self.dbu.getFileFullPath('ect_rbspb_0377_364_02.ptp.gz'))
 
     def test_getProcessFromInputProduct(self):
@@ -455,8 +463,8 @@ class DBUtilsGetTests(TestSetup):
         """getSatelliteMission"""
         val = self.dbu.getSatelliteMission(1)
         self.assertEqual(1, val.mission_id)
-        self.assertEqual(u'mageis_incoming', val.incoming_dir)
-        self.assertEqual(u'/n/space_data/cda/rbsp', val.rootdir)
+        self.assertEqual('mageis_incoming', val.incoming_dir)
+        self.assertEqual('/n/space_data/cda/rbsp', val.rootdir)
         self.assertRaises(NoResultFound, self.dbu.getSatelliteMission, 100)
         self.assertRaises(NoResultFound, self.dbu.getSatelliteMission, 'badval')
 
@@ -472,7 +480,7 @@ class DBUtilsGetTests(TestSetup):
 
     def test_getMissions(self):
         """getMissions"""
-        self.assertEqual([u'rbsp'], self.dbu.getMissions())
+        self.assertEqual(['rbsp'], self.dbu.getMissions())
 
     def test_getFileID(self):
         """getFileID"""
@@ -699,8 +707,8 @@ class DBUtilsGetTests(TestSetup):
         val = self.dbu.getFilesByDate([datetime.date(2013, 9, 10)] * 2, newest_version=True)
         self.assertEqual(129, len(val))
         filenames = sorted([v.filename for v in val])
-        ans = [u'ect_rbspa_0377_344_02.ptp.gz', 
-               u'ect_rbspa_0377_345_01.ptp.gz']
+        ans = ['ect_rbspa_0377_344_02.ptp.gz', 
+               'ect_rbspa_0377_345_01.ptp.gz']
         self.assertEqual(ans, filenames[:len(ans)])
 
     def test_getFilesByProduct(self):
@@ -742,12 +750,12 @@ class DBUtilsGetTests(TestSetup):
         val = self.dbu.getActiveInspectors()
         self.assertEqual(190, len(val))
         v2 = set([v[0] for v in val])
-        ans = set([u'/n/space_data/cda/rbsp/codes/inspectors/ect_L05_V1.0.0.py',
-                   u'/n/space_data/cda/rbsp/codes/inspectors/ect_L0_V1.0.0.py',
-                   u'/n/space_data/cda/rbsp/codes/inspectors/ect_L1_V1.0.0.py',
-                   u'/n/space_data/cda/rbsp/codes/inspectors/ect_L2_V1.0.0.py',
-                   u'/n/space_data/cda/rbsp/codes/inspectors/emfisis_V1.0.0.py',
-                   u'/n/space_data/cda/rbsp/codes/inspectors/rbsp_pre_MagEphem_insp.py'])
+        ans = set(['/n/space_data/cda/rbsp/codes/inspectors/ect_L05_V1.0.0.py',
+                   '/n/space_data/cda/rbsp/codes/inspectors/ect_L0_V1.0.0.py',
+                   '/n/space_data/cda/rbsp/codes/inspectors/ect_L1_V1.0.0.py',
+                   '/n/space_data/cda/rbsp/codes/inspectors/ect_L2_V1.0.0.py',
+                   '/n/space_data/cda/rbsp/codes/inspectors/emfisis_V1.0.0.py',
+                   '/n/space_data/cda/rbsp/codes/inspectors/rbsp_pre_MagEphem_insp.py'])
         self.assertEqual(ans, v2)
         v3 = set([v[-1] for v in val])
         self.assertEqual(set(range(1, 191)), v3)
@@ -1131,7 +1139,8 @@ class ProcessqueueTests(TestSetup):
         self.add_files()
         self.assertEqual(5, self.dbu.ProcessqueueLen())
         self.assertEqual([17, 18, 19, 20, 21], self.dbu.ProcessqueueGetAll())
-        self.assertEqual(zip([17, 18, 19, 20, 21], [None] * 5), self.dbu.ProcessqueueGetAll(version_bump=True))
+        self.assertEqual(list(zip([17, 18, 19, 20, 21], [None] * 5)),
+                         self.dbu.ProcessqueueGetAll(version_bump=True))
 
     def test_pq_getall2(self):
         """test self.ProcessqueueGetAll"""
@@ -1863,7 +1872,7 @@ class TestWithtestDB(unittest.TestCase):
             self.dbu.editTable('code', 'run_test.py', 'relative_path',
                                my_str='newscripts', replace_str='scripts')
         self.assertEqual(
-            'Multiple rows match run_test.py', cm.exception.message)
+            'Multiple rows match run_test.py', str(cm.exception))
 
     def testEditTableReplaceAfter(self):
         """Test editTable with a replace only after a flag"""
@@ -1961,7 +1970,7 @@ class TestWithtestDB(unittest.TestCase):
         for kwargs, msg in test_cases:
             with self.assertRaises(ValueError) as cm:
                 self.dbu.editTable('code', 1, 'arguments', **kwargs)
-            self.assertEqual(msg, cm.exception.message)
+            self.assertEqual(msg, str(cm.exception))
 
         #Tests that don't fit exactly the same pattern
         with self.assertRaises(ValueError) as cm:
@@ -1969,20 +1978,20 @@ class TestWithtestDB(unittest.TestCase):
                                after_flag='-f')
         self.assertEqual(
             'Only use after_flag with arguments column in Code table.',
-            cm.exception.message)
+            str(cm.exception))
         with self.assertRaises(ValueError) as cm:
             self.dbu.editTable('process', 1, 'arguments', combine=True,
                                after_flag='-f')
         self.assertEqual(
             'Only use after_flag with arguments column in Code table.',
-            cm.exception.message)
+            str(cm.exception))
 
         with self.assertRaises(AttributeError) as cm:
             self.dbu.editTable('nonexistent', 1, 'process_name',
                                ins_after='L1', my_str='_new')
         self.assertEqual(
             "'DButils' object has no attribute 'Nonexistent'",
-            cm.exception.message)
+            str(cm.exception))
 
     def testAddUnixTimeTable(self):
         """Add the table with Unix time"""

--- a/unit_tests/test_DButils.py
+++ b/unit_tests/test_DButils.py
@@ -1123,137 +1123,137 @@ class ProcessqueueTests(TestSetup):
     """Test all the processqueue functionality"""
 
     def add_files(self):
-        self.dbu.Processqueue.push([17, 18, 19, 20, 21])
+        self.dbu.ProcessqueuePush([17, 18, 19, 20, 21])
 
     def test_pq_getall(self):
-        """test self.Processqueue.getAll"""
-        self.assertEqual(0, self.dbu.Processqueue.len())
+        """test self.ProcessqueueGetAll"""
+        self.assertEqual(0, self.dbu.ProcessqueueLen())
         self.add_files()
-        self.assertEqual(5, self.dbu.Processqueue.len())
-        self.assertEqual([17, 18, 19, 20, 21], self.dbu.Processqueue.getAll())
-        self.assertEqual(zip([17, 18, 19, 20, 21], [None] * 5), self.dbu.Processqueue.getAll(version_bump=True))
+        self.assertEqual(5, self.dbu.ProcessqueueLen())
+        self.assertEqual([17, 18, 19, 20, 21], self.dbu.ProcessqueueGetAll())
+        self.assertEqual(zip([17, 18, 19, 20, 21], [None] * 5), self.dbu.ProcessqueueGetAll(version_bump=True))
 
     def test_pq_getall2(self):
-        """test self.Processqueue.getAll"""
-        self.assertEqual(0, self.dbu.Processqueue.len())
-        self.assertFalse(self.dbu.Processqueue.getAll())
-        self.assertFalse(self.dbu.Processqueue.getAll(version_bump=True))
+        """test self.ProcessqueueGetAll"""
+        self.assertEqual(0, self.dbu.ProcessqueueLen())
+        self.assertFalse(self.dbu.ProcessqueueGetAll())
+        self.assertFalse(self.dbu.ProcessqueueGetAll(version_bump=True))
 
     def test_pq_flush(self):
-        """test self.Processqueue.flush"""
+        """test self.ProcessqueueFlush"""
         self.add_files()
-        self.assertEqual(5, self.dbu.Processqueue.len())
-        self.dbu.Processqueue.flush()
-        self.assertEqual(0, self.dbu.Processqueue.len())
+        self.assertEqual(5, self.dbu.ProcessqueueLen())
+        self.dbu.ProcessqueueFlush()
+        self.assertEqual(0, self.dbu.ProcessqueueLen())
 
     def test_pq_remove(self):
-        """test self.Processqueue.remove"""
+        """test self.ProcessqueueRemove"""
         self.add_files()
-        self.assertEqual(5, self.dbu.Processqueue.len())
-        self.dbu.Processqueue.remove(20)
-        self.assertEqual(4, self.dbu.Processqueue.len())
-        pq = self.dbu.Processqueue.getAll()
+        self.assertEqual(5, self.dbu.ProcessqueueLen())
+        self.dbu.ProcessqueueRemove(20)
+        self.assertEqual(4, self.dbu.ProcessqueueLen())
+        pq = self.dbu.ProcessqueueGetAll()
         for v in [17, 18, 19, 21]:
             self.assertTrue(v in pq)
-        self.dbu.Processqueue.remove([17, 18])
-        self.assertEqual(2, self.dbu.Processqueue.len())
-        pq = self.dbu.Processqueue.getAll()
+        self.dbu.ProcessqueueRemove([17, 18])
+        self.assertEqual(2, self.dbu.ProcessqueueLen())
+        pq = self.dbu.ProcessqueueGetAll()
         for v in [19, 21]:
             self.assertTrue(v in pq)
-        self.dbu.Processqueue.remove('ect_rbspb_0377_381_03.ptp.gz')
-        self.assertEqual(1, self.dbu.Processqueue.len())
-        self.assertEqual([21], self.dbu.Processqueue.getAll())
+        self.dbu.ProcessqueueRemove('ect_rbspb_0377_381_03.ptp.gz')
+        self.assertEqual(1, self.dbu.ProcessqueueLen())
+        self.assertEqual([21], self.dbu.ProcessqueueGetAll())
 
     def test_pq_push(self):
-        """test self.Processqueue.push"""
-        self.assertEqual(0, self.dbu.Processqueue.len())
-        self.dbu.Processqueue.push(20)
-        self.assertEqual(1, self.dbu.Processqueue.len())
-        pq = self.dbu.Processqueue.getAll()
+        """test self.ProcessqueuePush"""
+        self.assertEqual(0, self.dbu.ProcessqueueLen())
+        self.dbu.ProcessqueuePush(20)
+        self.assertEqual(1, self.dbu.ProcessqueueLen())
+        pq = self.dbu.ProcessqueueGetAll()
         self.assertTrue(20 in pq)
         # push a value that is not there
-        self.assertFalse(self.dbu.Processqueue.push(214442))
-        self.assertFalse(self.dbu.Processqueue.push(20))
-        self.assertEqual([17, 18, 19, 21], self.dbu.Processqueue.push([17, 18, 19, 20, 21]))
+        self.assertFalse(self.dbu.ProcessqueuePush(214442))
+        self.assertFalse(self.dbu.ProcessqueuePush(20))
+        self.assertEqual([17, 18, 19, 21], self.dbu.ProcessqueuePush([17, 18, 19, 20, 21]))
 
     def test_pq_push_MAX_ADD(self):
-        """test self.Processqueue.push"""
-        self.assertEqual(0, self.dbu.Processqueue.len())
-        self.dbu._processqueuePush([17, 18, 19, 20, 21], MAX_ADD=2)
-        self.assertEqual(5, self.dbu.Processqueue.len())
+        """test self.ProcessqueuePush"""
+        self.assertEqual(0, self.dbu.ProcessqueueLen())
+        self.dbu.ProcessqueuePush([17, 18, 19, 20, 21], MAX_ADD=2)
+        self.assertEqual(5, self.dbu.ProcessqueueLen())
 
     def test_pq_len(self):
-        """test self.Processqueue.len"""
-        self.assertEqual(0, self.dbu.Processqueue.len())
+        """test self.ProcessqueueLen"""
+        self.assertEqual(0, self.dbu.ProcessqueueLen())
         self.add_files()
-        self.assertEqual(5, self.dbu.Processqueue.len())
+        self.assertEqual(5, self.dbu.ProcessqueueLen())
 
     def test_pq_pop(self):
-        """test self.Processqueue.pop"""
+        """test self.ProcessqueuePop"""
         self.add_files()
-        self.assertEqual(5, self.dbu.Processqueue.len())
-        self.dbu.Processqueue.pop(0)
-        self.assertEqual(4, self.dbu.Processqueue.len())
-        pq = self.dbu.Processqueue.getAll()
+        self.assertEqual(5, self.dbu.ProcessqueueLen())
+        self.dbu.ProcessqueuePop(0)
+        self.assertEqual(4, self.dbu.ProcessqueueLen())
+        pq = self.dbu.ProcessqueueGetAll()
         for v in [18, 19, 20, 21]:
             self.assertTrue(v in pq)
-        self.dbu.Processqueue.pop(2)
-        self.assertEqual(3, self.dbu.Processqueue.len())
-        pq = self.dbu.Processqueue.getAll()
+        self.dbu.ProcessqueuePop(2)
+        self.assertEqual(3, self.dbu.ProcessqueueLen())
+        pq = self.dbu.ProcessqueueGetAll()
         for v in [18, 19, 21]:
             self.assertTrue(v in pq)
 
     def test_pq_pop_reverse(self):
-        """test self.Processqueue.pop with negative indices"""
+        """test self.ProcessqueuePop with negative indices"""
         self.add_files()
-        self.assertEqual(5, self.dbu.Processqueue.len())
-        self.dbu.Processqueue.pop(-1)
-        self.assertEqual(4, self.dbu.Processqueue.len())
-        pq = self.dbu.Processqueue.getAll()
+        self.assertEqual(5, self.dbu.ProcessqueueLen())
+        self.dbu.ProcessqueuePop(-1)
+        self.assertEqual(4, self.dbu.ProcessqueueLen())
+        pq = self.dbu.ProcessqueueGetAll()
         for v in [17, 18, 19, 20]:
             self.assertTrue(v in pq)
-        self.dbu.Processqueue.pop(-2)
-        self.assertEqual(3, self.dbu.Processqueue.len())
-        pq = self.dbu.Processqueue.getAll()
+        self.dbu.ProcessqueuePop(-2)
+        self.assertEqual(3, self.dbu.ProcessqueueLen())
+        pq = self.dbu.ProcessqueueGetAll()
         for v in [17, 18, 20]:
             self.assertTrue(v in pq)
 
     def test_pq_get(self):
-        """test self.Processqueue.get"""
+        """test self.ProcessqueueGet"""
         self.add_files()
-        self.assertEqual(5, self.dbu.Processqueue.len())
-        self.assertEqual((17, None), self.dbu.Processqueue.get(0))
-        self.assertEqual(5, self.dbu.Processqueue.len())
-        self.assertEqual((19, None), self.dbu.Processqueue.get(2))
-        self.assertEqual(5, self.dbu.Processqueue.len())
+        self.assertEqual(5, self.dbu.ProcessqueueLen())
+        self.assertEqual((17, None), self.dbu.ProcessqueueGet(0))
+        self.assertEqual(5, self.dbu.ProcessqueueLen())
+        self.assertEqual((19, None), self.dbu.ProcessqueueGet(2))
+        self.assertEqual(5, self.dbu.ProcessqueueLen())
 
     def test_pq_get_reverse(self):
-        """test self.Processqueue.get with negative indices"""
+        """test self.ProcessqueueGet with negative indices"""
         self.add_files()
-        self.assertEqual(5, self.dbu.Processqueue.len())
-        self.assertEqual((21, None), self.dbu.Processqueue.get(-1))
-        self.assertEqual(5, self.dbu.Processqueue.len())
-        self.assertEqual((20, None), self.dbu.Processqueue.get(-2))
-        self.assertEqual(5, self.dbu.Processqueue.len())
+        self.assertEqual(5, self.dbu.ProcessqueueLen())
+        self.assertEqual((21, None), self.dbu.ProcessqueueGet(-1))
+        self.assertEqual(5, self.dbu.ProcessqueueLen())
+        self.assertEqual((20, None), self.dbu.ProcessqueueGet(-2))
+        self.assertEqual(5, self.dbu.ProcessqueueLen())
 
     def test_pq_clean(self):
-        """test self.Processqueue.clean"""
+        """test self.ProcessqueueClean"""
         self.add_files()
-        self.assertEqual(5, self.dbu.Processqueue.len())
-        self.dbu.Processqueue.clean()
-        self.assertEqual(1, self.dbu.Processqueue.len())
-        pq = self.dbu.Processqueue.getAll()
+        self.assertEqual(5, self.dbu.ProcessqueueLen())
+        self.dbu.ProcessqueueClean()
+        self.assertEqual(1, self.dbu.ProcessqueueLen())
+        pq = self.dbu.ProcessqueueGetAll()
         self.assertTrue(17 in pq)
 
     def test_pq_rawadd(self):
-        """test self.Processqueue.rawadd"""
-        self.assertEqual(0, self.dbu.Processqueue.len())
-        self.dbu.Processqueue.rawadd(20)
-        self.assertEqual(1, self.dbu.Processqueue.len())
-        pq = self.dbu.Processqueue.getAll()
+        """test self.ProcessqueueRawadd"""
+        self.assertEqual(0, self.dbu.ProcessqueueLen())
+        self.dbu.ProcessqueueRawadd(20)
+        self.assertEqual(1, self.dbu.ProcessqueueLen())
+        pq = self.dbu.ProcessqueueGetAll()
         self.assertTrue(20 in pq)
-        self.dbu.Processqueue.rawadd(20000)
-        pq = self.dbu.Processqueue.pop(1)
+        self.dbu.ProcessqueueRawadd(20000)
+        pq = self.dbu.ProcessqueuePop(1)
         self.assertRaises(DButils.DBNoData, self.dbu.getFileID, pq)
 
 

--- a/unit_tests/test_DButils.py
+++ b/unit_tests/test_DButils.py
@@ -1831,6 +1831,16 @@ class TestWithtestDB(unittest.TestCase):
 
         self.assertTrue(all([self.tempD in v for v in out]))
 
+    def test_getChildTreeNoOutput(self):
+        """getChildTree for processes w/o output"""
+        tmp = self.dbu.getChildTree(3)
+        ans = set([])
+        self.assertFalse(set(tmp).difference(ans))
+        # Explicitly make it null (it's empty string in the db)
+        self.dbu.getEntry('Process', 2).output_product = None
+        tmp = self.dbu.getChildTree(3)
+        self.assertFalse(set(tmp).difference(ans))
+
     def testUpdateCodeNewestVersion(self):
         """Set the newest version flag on a code"""
         #Test precondition

--- a/unit_tests/test_DButils.py
+++ b/unit_tests/test_DButils.py
@@ -193,6 +193,15 @@ class DBUtilsOtherTests(TestSetup):
         self.assertRaises(DButils.DBNoData, self.dbu.getFileID, file_id)
         self.assertEqual(self.dbu.session.query(self.dbu.File).count(), 6680)
 
+    def test_purgeFileFromDBByName(self):
+        """purgeFileFromDB, given a filename"""
+        self.assertEqual(self.dbu.session.query(self.dbu.File).count(), 6681)
+        self.dbu._purgeFileFromDB('ect_rbspb_0377_356_01.ptp.gz')
+        self.assertRaises(DButils.DBNoData, self.dbu.getFileID, 123)
+        self.assertRaises(DButils.DBNoData, self.dbu.getFileID,
+                          'ect_rbspb_0377_356_01.ptp.gz')
+        self.assertEqual(self.dbu.session.query(self.dbu.File).count(), 6680)
+
     def test_nameSubProduct(self):
         """_nameSubProduct"""
         self.assertTrue(self.dbu._nameSubProduct(None, 1) is None)

--- a/unit_tests/test_Diskfile.py
+++ b/unit_tests/test_Diskfile.py
@@ -40,12 +40,12 @@ class DiskfileStaticTests(unittest.TestCase):
         """ calcDigest  should behave correctly"""
         self.assertRaises(Diskfile.DigestError, Diskfile.calcDigest, 'idontexist.file')
         with open('IamAfileThatExists.file', 'wb') as f:
-            f.write('I am some text in a file')
+            f.write(b'I am some text in a file')
         real_ans = 'aa42c02f50c92203be933747670bdd512848385e'
         ans = Diskfile.calcDigest('IamAfileThatExists.file')
         self.assertEqual(real_ans, ans)
         with open('IamAfileThatExists.file', 'wb+') as f:
-            f.write('I m more text')
+            f.write(b'I m more text')
         ans = Diskfile.calcDigest('IamAfileThatExists.file')
         self.assertNotEqual (real_ans, ans)
         f.close()
@@ -62,7 +62,7 @@ class DiskfileTests(TestSetup):
         """given a file input that is not writeable WriteError"""
         try:
             with open('IamAfileThatExists.file', 'wb') as f:
-                f.write('I am some text in a file')
+                f.write(b'I am some text in a file')
             os.chmod('IamAfileThatExists.file', stat.S_IRUSR)
             self.assertRaises(Diskfile.WriteError, Diskfile.Diskfile, 'IamAfileThatExists.file', self.dbu)
 
@@ -73,7 +73,7 @@ class DiskfileTests(TestSetup):
     def test_init(self):
         """init does some checking"""
         with open('IamAfileThatExists.file', 'wb') as f:
-            f.write('I am some text in a file')
+            f.write(b'I am some text in a file')
         try:
             a = Diskfile.Diskfile('IamAfileThatExists.file', self.dbu)
         finally:
@@ -84,7 +84,7 @@ class DiskfileTests(TestSetup):
         # File must exist...
         reprfile = 'reprtest.txt'
         with open(reprfile, 'wb') as f:
-            f.write('I am some text in a file')
+            f.write(b'I am some text in a file')
 
         df = Diskfile.Diskfile(reprfile, self.dbu)
 

--- a/unit_tests/test_Inspector.py
+++ b/unit_tests/test_Inspector.py
@@ -70,6 +70,7 @@ class InspectorClass(unittest.TestCase):
 
     def tearDown(self):
         super(InspectorClass, self).tearDown()
+        self.dbu.closeDB()
         remove_tree(self.tempD)
 
     def test_inspector(self):
@@ -85,7 +86,6 @@ class InspectorClass(unittest.TestCase):
             dbp_testing.testsdir, 'inspector', 'testDB_001_first.raw')
         self.assertEqual(repr(Diskfile.Diskfile(goodfile, self.dbu)), repr(self.inspect.Inspector(goodfile, self.dbu, 1,)()))
         #self.assertEqual(None, self.inspect.Inspector(goodfile, self.dbu, 1,).extract_YYYYMMDD())
-        
         # This inspector sets the data_level - not allowed
         inspect = imp.load_source('inspect', os.path.join(
             dbp_testing.testsdir, 'inspector', 'rot13_L1_dlevel.py'))

--- a/unit_tests/test_Inspector.py
+++ b/unit_tests/test_Inspector.py
@@ -78,19 +78,19 @@ class InspectorClass(unittest.TestCase):
         # File doesn't match the inspector pattern...
         self.assertEqual(None, self.inspect.Inspector(os.path.join(
             dbp_testing.testsdir, 'inspector', 'testDB_01_first.raw'),
-                                                      self.dbu, 1,))
+                                                      self.dbu, 1,)())
 
         # File matches pattern...
         goodfile = os.path.join(
             dbp_testing.testsdir, 'inspector', 'testDB_001_first.raw')
-        self.assertEqual(repr(Diskfile.Diskfile(goodfile, self.dbu)), repr(self.inspect.Inspector(goodfile, self.dbu, 1,)))
+        self.assertEqual(repr(Diskfile.Diskfile(goodfile, self.dbu)), repr(self.inspect.Inspector(goodfile, self.dbu, 1,)()))
         #self.assertEqual(None, self.inspect.Inspector(goodfile, self.dbu, 1,).extract_YYYYMMDD())
         
         # This inspector sets the data_level - not allowed
         inspect = imp.load_source('inspect', os.path.join(
             dbp_testing.testsdir, 'inspector', 'rot13_L1_dlevel.py'))
         with warnings.catch_warnings(record=True) as w:
-            self.assertEqual(repr(Diskfile.Diskfile(goodfile, self.dbu)), repr(self.inspect.Inspector(goodfile, self.dbu, 1,)))
+            self.assertEqual(repr(Diskfile.Diskfile(goodfile, self.dbu)), repr(self.inspect.Inspector(goodfile, self.dbu, 1,)()))
         self.assertEqual(len(w), 1)
         self.assertTrue(isinstance(w[0].message, UserWarning))
         self.assertEqual('Inspector rot13_L1_dlevel.py:  set level to 2.0, '
@@ -102,7 +102,7 @@ class InspectorClass(unittest.TestCase):
             dbp_testing.testsdir, 'inspector', 'testDB_01_first.raw')
         inspect = imp.load_source('inspect', os.path.join(
             dbp_testing.testsdir, 'inspector', 'rot13_L1.py'))
-        self.assertEqual(None, inspect.Inspector(badfile, self.dbu, 1,))
+        self.assertEqual(None, inspect.Inspector(badfile, self.dbu, 1,)())
 
     def test_inspector_regex(self):
         """Test regex expansion of inspector"""
@@ -122,23 +122,21 @@ class InspectorClass(unittest.TestCase):
         fspec = os.path.join(self.tempD, 'testDB_2016-01-01.cat')
         open(fspec, 'w').close()
         testi(fspec, self.dbu, 1)
-        # The metaclass programming makes this awkward, need to extract
-        # members of an intentionally ephemeral class...
-        last = testi.__ephemeral_encapsulated__.last
+        last = testi.last
         self.assertEqual('testDB_((19|2\\d)\\d\\d(0\\d|1[0-2])[0-3]\\d).cat',
                          last['filenameregex'])
         # Force a different pattern
         p = self.dbu.getEntry('Product', 1)
         p.format = 'testDB_{APID}.cat'
         testi(fspec, self.dbu, 1)
-        last = testi.__ephemeral_encapsulated__.last
+        last = testi.last
         self.assertEqual('testDB_([\\da-fA-F]+).cat',
                          last['filenameregex'])
         # Force a pattern we don't expand
         p = self.dbu.getEntry('Product', 1)
         p.format = 'testDB_{nonsense}.cat'
         testi(fspec, self.dbu, 1)
-        last = testi.__ephemeral_encapsulated__.last
+        last = testi.last
         self.assertEqual('testDB_(.*).cat',
                          last['filenameregex'])
         # testi goes out of scope here, so will clean up db objects

--- a/unit_tests/test_Utils.py
+++ b/unit_tests/test_Utils.py
@@ -34,6 +34,7 @@ class UtilsTests(unittest.TestCase):
 
     def tearDown(self):
         super(UtilsTests, self).tearDown()
+        self.dbu.closeDB()
         remove_tree(self.tempD)
 
     def test_dirSubs(self):
@@ -77,15 +78,23 @@ class UtilsTests(unittest.TestCase):
 
     def test_chunker(self):
         """chunker()"""
-        self.assertEqual(list(Utils.chunker(range(10), 3)), [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9]])
-        self.assertEqual(list(Utils.chunker(range(10), 4)), [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9]])
-        self.assertEqual(list(Utils.chunker(range(10), 4)), [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9]])
-        self.assertEqual(list(Utils.chunker(range(10), 10)), [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]])
-        self.assertEqual(list(Utils.chunker(range(10), 20)), [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]])
+        # Turn iterator-of-iterators into list-of-lists
+        def unfold_iter(i):
+            return [list(j) for j in i]
+        self.assertEqual(unfold_iter(Utils.chunker(range(10), 3)),
+                         [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9]])
+        self.assertEqual(unfold_iter(Utils.chunker(range(10), 4)),
+                         [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9]])
+        self.assertEqual(unfold_iter(Utils.chunker(range(10), 4)),
+                         [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9]])
+        self.assertEqual(unfold_iter(Utils.chunker(range(10), 10)),
+                         [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]])
+        self.assertEqual(unfold_iter(Utils.chunker(range(10), 20)),
+                         [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]])
 
     def test_unique(self):
         """unique"""
-        self.assertEqual(Utils.unique(range(5)), range(5))
+        self.assertEqual(Utils.unique(range(5)), list(range(5)))
         self.assertEqual(Utils.unique([1, 1, 2, 2, 3]), [1, 2, 3])
         self.assertEqual(Utils.unique([1, 1, 3, 2, 2, 3]), [1, 3, 2])
 

--- a/unit_tests/test_Utils.py
+++ b/unit_tests/test_Utils.py
@@ -14,6 +14,7 @@ try:
 except:
     import io as StringIO
 
+import dbp_testing
 from dbprocessing import Utils
 from dbprocessing import DButils
 from dbprocessing import Version
@@ -21,6 +22,9 @@ from dbprocessing import Version
 
 class UtilsTests(unittest.TestCase):
     """Tests for DBfile class"""
+
+    longMessage = True
+    maxDiff = None
 
     def setUp(self):
         super(UtilsTests, self).setUp()
@@ -203,6 +207,76 @@ class UtilsTests(unittest.TestCase):
     def test_readconfig(self):
         """test readconfig"""
         self.assertEqual({'section2': {'sect2a': 'sect2_value1'}, 'section1': {'sect1a': 'sect1_value1', 'sect1b': 'sect1_value2'}}, Utils.readconfig(os.path.join(os.path.dirname(__file__), 'testconfig.txt')))
+
+    def test_readconfigAll(self):
+        """Check readconfig output, as used in addFromConfig"""
+
+        conf = Utils.readconfig(os.path.join(
+            dbp_testing.testsdir, 'data', 'configs', 'testDB.conf'))
+        # Regression testing, just copy-pasted from the actual output
+        ans = {
+            'satellite': {'satellite_name': '{MISSION}-a'},
+            'product_concat': {
+                'inspector_output_interface': '1',
+                'inspector_version': '1.0.0',
+                'inspector_arguments': '-q',
+                'format': 'testDB_{nnn}.cat',
+                'level': '1.0',
+                'product_description': '',
+                'relative_path': 'L1',
+                'inspector_newest_version': 'True',
+                'inspector_relative_path': 'codes/inspectors',
+                'inspector_date_written': '2016-05-31',
+                'inspector_filename': 'rot13_L1.py',
+                'inspector_description': 'Level 1',
+                'inspector_active': 'True',
+                'product_name': '{MISSION}_rot13_L1'},
+            'product_rot13': {
+                'inspector_output_interface': '1',
+                'inspector_version': '1.0.0',
+                'inspector_arguments': '-q',
+                'format': 'testDB_{nnn}.rot',
+                'level': '2.0',
+                'product_description': '',
+                'relative_path': 'L2',
+                'inspector_newest_version': 'True',
+                'inspector_relative_path': 'codes/inspectors',
+                'inspector_date_written': '2016-05-31',
+                'inspector_filename': 'rot13_L2.py',
+                'inspector_description': 'Level 2',
+                'inspector_active': 'True',
+                'product_name': '{MISSION}_rot13_L2'},
+            'mission': {
+                'incoming_dir': 'L0',
+                'rootdir': '/home/myles/dbprocessing/test_DB',
+                'mission_name': 'testDB'},
+            'instrument': {'instrument_name': 'rot13'},
+            'process_rot13_L1-L2': {'code_cpu': '1',
+                'code_start_date': '2010-09-01',
+                'code_stop_date': '2020-01-01',
+                'code_filename': 'run_rot13_L1toL2.py',
+                'code_relative_path': 'scripts',
+                'required_input1': ('product_concat', 0, 0),
+                'code_version': '1.0.0',
+                'process_name': 'rot_L1toL2',
+                'code_output_interface': '1',
+                'code_newest_version': 'True',
+                'code_date_written': '2016-05-31',
+                'code_description': 'Python L1->L2',
+                'output_product': 'product_rot13',
+                'code_active': 'True',
+                'code_arguments': '',
+                'extra_params': '',
+                'output_timebase': 'FILE',
+                'code_ram': '1'}
+        }
+        key_diff = set(ans.keys()).symmetric_difference(conf.keys())
+        if key_diff:
+            self.fail('Keys in only one of actual/expected: '
+                      + ', '.join(key_diff))
+        for k in ans:
+            self.assertEqual(ans[k], conf[k], k)
+        self.assertEqual(ans, conf)
 
     def test_datetimeToDate(self):
         """test datetimeToDate"""

--- a/unit_tests/test_Version.py
+++ b/unit_tests/test_Version.py
@@ -24,8 +24,8 @@ class VersionTests(unittest.TestCase):
         ver.incInterface()
         self.assertEqual(Version.Version(2, 0, 0), ver)
 
-    def test_Version_repr(self):
-        """__repr__ should have a known output"""
+    def test_Version_str(self):
+        """__str__ should have a known output"""
         invals = ( Version.Version(1, 0, 1), Version.Version(5, 0, 1),
                   Version.Version(1, 3, 1) )
         answers = ( '1.0.1', '5.0.1', '1.3.1' )
@@ -108,6 +108,14 @@ class VersionTests(unittest.TestCase):
     def test_repr(self):
         """__repr__ has known output"""
         self.assertEqual(Version.Version(1,0,1).__repr__(), 'Version: 1.0.1')
+
+    def test_format(self):
+        """Version can be interpolated into a format string"""
+        self.assertEqual(
+            'v. 1.2.3', 'v. {}'.format(Version.Version(1, 2, 3)))
+        kwargs = {'ans': Version.Version(1, 2, 3)}
+        self.assertEqual(
+            'v. 1.2.3  ', 'v. {ans:7}'.format(**kwargs))
 
     def test_fromString(self):
         """fromString"""

--- a/unit_tests/test_addFromConfig.py
+++ b/unit_tests/test_addFromConfig.py
@@ -8,7 +8,8 @@ import unittest
 import dbp_testing
 dbp_testing.add_scripts_to_path()
 
-from addFromConfig import configCheck, readconfig, _sectionCheck, _keysCheck, _keysRemoveExtra, _keysPresentCheck, _fileTest
+import dbprocessing.Utils
+from addFromConfig import configCheck, _sectionCheck, _keysCheck, _keysRemoveExtra, _keysPresentCheck, _fileTest
 
 class addFromConfig(unittest.TestCase):
     """Tests for addFromConfig script"""
@@ -16,80 +17,10 @@ class addFromConfig(unittest.TestCase):
     longMessage = True
     maxDiff = None
 
-    def test_readconfig(self):
-        """Does readconfig match the expected output"""
-
-        conf = readconfig(os.path.join(
-            dbp_testing.testsdir, 'data', 'configs', 'testDB.conf'))
-        # Regression testing, just copy-pasted from the actual output
-        ans = {
-            'satellite': {'satellite_name': '{MISSION}-a'},
-            'product_concat': {
-                'inspector_output_interface': '1',
-                'inspector_version': '1.0.0',
-                'inspector_arguments': '-q',
-                'format': 'testDB_{nnn}.cat',
-                'level': '1.0',
-                'product_description': '',
-                'relative_path': 'L1',
-                'inspector_newest_version': 'True',
-                'inspector_relative_path': 'codes/inspectors',
-                'inspector_date_written': '2016-05-31',
-                'inspector_filename': 'rot13_L1.py',
-                'inspector_description': 'Level 1',
-                'inspector_active': 'True',
-                'product_name': '{MISSION}_rot13_L1'},
-            'product_rot13': {
-                'inspector_output_interface': '1',
-                'inspector_version': '1.0.0',
-                'inspector_arguments': '-q',
-                'format': 'testDB_{nnn}.rot',
-                'level': '2.0',
-                'product_description': '',
-                'relative_path': 'L2',
-                'inspector_newest_version': 'True',
-                'inspector_relative_path': 'codes/inspectors',
-                'inspector_date_written': '2016-05-31',
-                'inspector_filename': 'rot13_L2.py',
-                'inspector_description': 'Level 2',
-                'inspector_active': 'True',
-                'product_name': '{MISSION}_rot13_L2'},
-            'mission': {
-                'incoming_dir': 'L0',
-                'rootdir': '/home/myles/dbprocessing/test_DB',
-                'mission_name': 'testDB'},
-            'instrument': {'instrument_name': 'rot13'},
-            'process_rot13_L1-L2': {'code_cpu': '1',
-                'code_start_date': '2010-09-01',
-                'code_stop_date': '2020-01-01',
-                'code_filename': 'run_rot13_L1toL2.py',
-                'code_relative_path': 'scripts',
-                'required_input1': ('product_concat', 0, 0),
-                'code_version': '1.0.0',
-                'process_name': 'rot_L1toL2',
-                'code_output_interface': '1',
-                'code_newest_version': 'True',
-                'code_date_written': '2016-05-31',
-                'code_description': 'Python L1->L2',
-                'output_product': 'product_rot13',
-                'code_active': 'True',
-                'code_arguments': '',
-                'extra_params': '',
-                'output_timebase': 'FILE',
-                'code_ram': '1'}
-        }
-        key_diff = set(ans.keys()).symmetric_difference(conf.keys())
-        if key_diff:
-            self.fail('Keys in only one of actual/expected: '
-                      + ', '.join(key_diff))
-        for k in ans:
-            self.assertEqual(ans[k], conf[k], k)
-        self.assertEqual(ans, conf)
-
     def test_sectionCheck_Valid(self):
         """Make sure no Exceptions are thrown for a valid config"""
         try:
-            conf = readconfig(os.path.join(
+            conf = dbprocessing.Utils.readconfig(os.path.join(
                 dbp_testing.testsdir, 'data', 'configs', 'testDB.conf'))
             _sectionCheck(conf)
         except Exception as e:
@@ -97,19 +28,19 @@ class addFromConfig(unittest.TestCase):
 
     def test_sectionCheck_MissingMission(self):
         """Make sure it notices Mission is missing"""
-        conf = readconfig(os.path.join(
+        conf = dbprocessing.Utils.readconfig(os.path.join(
             dbp_testing.testsdir, 'data', 'configs', 'testDB_noMission.conf'))
         self.assertRaises(ValueError, _sectionCheck, conf)
 
     def test_sectionCheck_FakeSection(self):
         """Make sure it notices there's a fake section"""
-        conf = readconfig(os.path.join(
+        conf = dbprocessing.Utils.readconfig(os.path.join(
             dbp_testing.testsdir, 'data', 'configs', 'testDB_fakeSection.conf'))
         self.assertRaises(ValueError, _sectionCheck, conf)
 
     def test_keysCheck_Valid(self):
         """Make sure no Exceptions are thrown for a valid config"""
-        conf = readconfig(os.path.join(
+        conf = dbprocessing.Utils.readconfig(os.path.join(
             dbp_testing.testsdir, 'data', 'configs', 'testDB.conf'))
         try:
             for key in conf.keys():
@@ -119,36 +50,36 @@ class addFromConfig(unittest.TestCase):
 
     def test_keysCheck_MissingRequired(self):
         """Make sure it notices missing required keys"""
-        conf = readconfig(os.path.join(
+        conf = dbprocessing.Utils.readconfig(os.path.join(
             dbp_testing.testsdir, 'data', 'configs', 'testDB_missingKey.conf'))
         self.assertRaises(ValueError, _keysCheck, conf, 'mission')
 
     def test_keysRemoveExtra(self):
         """Make sure it removes extra keys"""
-        validResult = readconfig(os.path.join(
+        validResult = dbprocessing.Utils.readconfig(os.path.join(
             dbp_testing.testsdir, 'data', 'configs', 'testDB.conf'))
 
-        conf = _keysRemoveExtra(readconfig(os.path.join(
+        conf = _keysRemoveExtra(dbprocessing.Utils.readconfig(os.path.join(
             dbp_testing.testsdir, 'data', 'configs', 'testDB_extraKey.conf')), 'mission')
         self.assertEqual(validResult['mission'], conf)
 
     def test_keysPresentCheck_Valid(self):
         try:
-            conf = readconfig(os.path.join(
+            conf = dbprocessing.Utils.readconfig(os.path.join(
                 dbp_testing.testsdir, 'data', 'configs', 'testDB.conf'))
             _keysPresentCheck(conf)
         except Exception as e:
             self.fail(e)
 
     def test_keysPresentCheck_Invalid(self):
-        conf = readconfig(os.path.join(
+        conf = dbprocessing.Utils.readconfig(os.path.join(
             dbp_testing.testsdir, 'data', 'configs',
             'testDB_missingProduct.conf'))
         self.assertRaises(ValueError, _keysPresentCheck, conf)
 
     def test_keysPresentCheck_Trigger(self):
         try:
-            conf = readconfig(os.path.join(
+            conf = dbprocessing.Utils.readconfig(os.path.join(
                 dbp_testing.testsdir, 'data', 'configs', 'testDB_trigger.conf'))
             _keysPresentCheck(conf)
         except Exception as e:
@@ -168,8 +99,9 @@ class addFromConfig(unittest.TestCase):
 
     def test_NoInputs(self):
         """Create a process with no inputs"""
-        conf = readconfig(os.path.join(dbp_testing.testsdir, 'data', 'configs',
-                                       'testDB_processNoInputs.conf'))
+        conf = dbprocessing.Utils.readconfig(os.path.join(
+            dbp_testing.testsdir, 'data', 'configs',
+            'testDB_processNoInputs.conf'))
         self.assertEqual(
             {'code_active': 'True',
              'code_arguments': '',
@@ -191,6 +123,7 @@ class addFromConfig(unittest.TestCase):
             },
             conf['process_no_input'])
         configCheck(conf)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/unit_tests/test_dbprocessing.py
+++ b/unit_tests/test_dbprocessing.py
@@ -37,6 +37,8 @@ class ProcessQueueTestsBase(unittest.TestCase, dbp_testing.AddtoDBMixin):
 
     def tearDown(self):
         """Remove the db and working tree"""
+        self.dbu.closeDB() # Before the database is removed...
+        del self.dbu
         # Unfortunately all the cleanup is in the destructor
         del self.pq
         shutil.rmtree(self.td)

--- a/unit_tests/test_dbprocessing.py
+++ b/unit_tests/test_dbprocessing.py
@@ -71,6 +71,15 @@ class BuildChildrenTests(ProcessQueueTestsBase):
             rm.make_command_line(rundir='')
             actual.append(rm.cmdline)
         for i, (e, a) in enumerate(zip(expected, actual)):
+            # Sort the input files, identified by having 'data'
+            # in there (so not argument or output); the order
+            # of input files doesn't matter. (Don't change function inputs.)
+            idx_exp = [j for j in range(len(e)) if '/data/' in e[j]]
+            idx_act = [j for j in range(len(a)) if '/data/' in a[j]]
+            e = e[:idx_exp[0]] + sorted(e[idx_exp[0]:idx_exp[-1]+1]) \
+                + e[idx_exp[-1]+1:]
+            a = a[:idx_act[0]] + sorted(a[idx_act[0]:idx_act[-1]+1]) \
+                + a[idx_act[-1]+1:]
             self.assertEqual(e, a, 'Command {}'.format(i))
 
     def testSimple(self):

--- a/unit_tests/test_dbprocessing.py
+++ b/unit_tests/test_dbprocessing.py
@@ -475,7 +475,7 @@ class ProcessQueueTests(ProcessQueueTestsBase):
         l0pid = self.addProduct('level 0')
         fid = self.addFile('level_0_20120101_v1.0.0', l0pid)
         self.assertEqual(1, self.pq._reprocessBy())
-        self.assertEqual((fid, None), self.dbu.Processqueue.pop())
+        self.assertEqual((fid, None), self.dbu.ProcessqueuePop())
 
 
 class GetRequiredProductsTests(ProcessQueueTestsBase):


### PR DESCRIPTION
This PR provides Python 3 support and fixes a couple of small issues that were found along the way, mostly with scripts. Python 2 is still supported (same code).

The "port" consisted of:

- Get the unit tests all working in 3 (and still in 2). In some cases tests failed not because the code was bad, but because the ordering of things was different in Python 3, for cases where ordering was not guaranteed. Relates to #69 and probably some issues @dnadeau-lanl was having.
- Process all PSP/ISOIS 2018 data using the new dbprocessing, in both Python 2 and 3. Outputs were compared, no changes.
- Every single script in the `scripts` directory was checked with 2to3 (although the output was not blindly accepted), then run and patched up if the output wasn't the same in 2 and 3. For a lot of these, there were issues where Python 3 shuts down the interpreter in a different order. If a `DButils` instance is still instantiated at shutdown, its `__del__` method may be called after sqlalchemy is shut down, and so the `CloseDB` method fails. So many scripts were updated to explicitly delete the `DButils` instance if it didn't go out of scope before the end of the script.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] (N/A) Major new functionality has appropriate Sphinx documentation
- [X] Added an entry to release notes if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked in the description (use `Closes #` if this PR closes the issue, or some other reference, such as `See #` if it is related in some other way)
