### PR TITLE
Fix addFromConfig for processes with no output product

### DIFF
--- a/scripts/addFromConfig.py
+++ b/scripts/addFromConfig.py
@@ -248,7 +248,7 @@ def addStuff(cfg, options):
             tmp = dict((k, cfg[p][k]) for k in cfg[p] if not k.startswith('code') and 'input' not in k)
             # need to replace the output product with the right ID
             # if it is a key then have to get the name from cfg, or it is a name itself
-            if tmp['output_product'] is not '':
+            if tmp['output_product'] != '':
                 tmp['output_product'] = cfg[tmp['output_product']]['product_id']
             p_id = dbu.addProcess(**tmp)
             print('Added Process: {0} {1}'.format(p_id, dbu.getEntry('Process', p_id).process_name))

--- a/unit_tests/data/configs/testDB_processNoOutputs.conf
+++ b/unit_tests/data/configs/testDB_processNoOutputs.conf
@@ -1,0 +1,49 @@
+[mission]
+mission_name = testDB
+rootdir = /home/myles/dbprocessing/test_DB
+codedir = /home/myles/dbprocessing/test_DB
+inspectordir = /home/myles/dbprocessing/test_DB
+errordir = /home/myles/dbprocessing/test_DB/errors
+incoming_dir = L0
+
+[satellite]
+satellite_name = {MISSION}-a
+
+[instrument]
+instrument_name = rot13
+
+[product_input_only]
+product_name = input_only
+relative_path = L1
+level = 1.0
+format = input_only_{Y}{m}{d}_v{VERSION}.out
+product_description = Input for process with no output
+inspector_filename = rot13_L1.py
+inspector_relative_path = codes/inspectors
+inspector_description = Level 1
+inspector_version = 1.0.0
+inspector_output_interface = 1
+inspector_active = True
+inspector_date_written = 2016-05-31
+inspector_newest_version = True
+inspector_arguments = -q
+
+[process_no_output]
+process_name = no_output
+required_input1 = product_input_only
+output_product =
+output_timebase = RUN
+extra_params =
+code_filename = no_output.py
+code_relative_path = scripts
+code_start_date = 2010-09-01
+code_stop_date = 2020-01-01
+code_description = Creates no output
+code_version = 1.0.0
+code_output_interface = 1
+code_active = True
+code_date_written = 2016-05-31
+code_newest_version = True
+code_arguments =
+code_cpu = 1
+code_ram = 1

--- a/unit_tests/test_addFromConfig.py
+++ b/unit_tests/test_addFromConfig.py
@@ -124,6 +124,34 @@ class addFromConfig(unittest.TestCase):
             conf['process_no_input'])
         configCheck(conf)
 
+    def test_NoOutputs(self):
+        """Create a process with no outputs"""
+        conf = dbprocessing.Utils.readconfig(os.path.join(
+            dbp_testing.testsdir, 'data', 'configs',
+            'testDB_processNoOutputs.conf'))
+        self.assertEqual(
+            {'code_active': 'True',
+             'code_arguments': '',
+             'code_cpu': '1',
+             'code_date_written': '2016-05-31',
+             'code_description': 'Creates no output',
+             'code_filename': 'no_output.py',
+             'code_newest_version': 'True',
+             'code_output_interface': '1',
+             'code_ram': '1',
+             'code_relative_path': 'scripts',
+             'code_start_date': '2010-09-01',
+             'code_stop_date': '2020-01-01',
+             'code_version': '1.0.0',
+             'extra_params': '',
+             'output_product': '',
+             'output_timebase': 'RUN',
+             'process_name': 'no_output',
+             'required_input1': ('product_input_only', 0, 0),
+            },
+            conf['process_no_output'])
+        configCheck(conf)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
addFromConfig no longer works for processes with no output product on Python 2.7. This is due to a comparison of empty strings with "is" in a situation where one might be in Unicode. This comparison has been around for awhile--I think it only became a problem when some of the config file handling was consolidated into a single place, and not explicitly cast to str in Python 2.

This PR changes to a simple equality comparison. It also adds a unit test to addFromConfig for the no-output case. It's worth noting the unit test does _not_ catch the problem, as it's in the non-unit-tested (and not really easily testable) portion of addFromConfig. In lieu of that, I assert that the PSP config does not successfully load into a database with the previous addFromConfig, but does work with this PR.

Long-term we need to rearchitect addFromConfig to be more testable, but a story for another day.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] (N/A) Major new functionality has appropriate Sphinx documentation
- [X] (N/A) Added an entry to release notes if fixing a major bug or providing a major new feature
- [X] (see above) New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked in the description (use `Closes #` if this PR closes the issue, or some other reference, such as `See #` if it is related in some other way)
