### PR TITLE
add count/exist/quiet options to printProcessQueue

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -29,6 +29,13 @@ pull/54>`_).
 Python 3 support was added.  (`77 <https://github.com/spacepy/dbprocessing/
 pull/77>`_).
 
+Added options :option:`printProcessQueue --count`,
+:option:`printProcessQueue --exist`, and :option:`printProcessQueue
+--quiet` to allow flow control in shell scripts based on the process
+queue state. (`87
+<https://github.com/spacepy/dbprocessing/issues/87>`_, `88
+<https://github.com/spacepy/dbprocessing/pull/88>`_)
+
 Deprecations and removals
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -305,15 +305,45 @@ Prints a table of info about files or products or processes.
 .. option:: database The name of the database to print table of
 .. option:: field Either Product or Mission (more to come)
 
+.. _scripts_printProcessQueue:
+
 printProcessQueue.py
 --------------------
 .. program:: printProcessQueue
 
 Prints the process queue.
 
-.. option:: database The name of the database to print the queue of
-.. option:: -o, --output The name of the file to output to(if blank, print to stdout)
-.. option:: --html Output in HTML
+.. option:: database
+
+   The name of the database to print the queue of
+
+.. option:: -c, --count
+
+   Set the return code to the number of files in the queue. If there
+   are more than 255 files, set to 255. With this option, it is impossible
+   to differentiate between an error and a single-element process queue based
+   on return code. Mutually exclusive with :option:`-e`, :option:`--exist`.
+
+.. option:: -e, --exist
+
+   Set the return code based on whether there are any files in the process
+   queue: 0 (shell True) if there are, 1 (shell False) if there are no files.
+   With this option, it is impossible to differentiate between an error and
+   an empty process queue based on return code. Mutually exclusive with
+   :option:`-c`, :option:`--count`.
+
+.. option:: --html
+
+   Provide output in HTML (default text).
+
+.. option:: -o filename, --output filename
+
+   The name of the file to output to (if not specified, output to stdout).
+
+.. option:: -q, --quiet
+
+   Quiet mode: produce no output. Mutually exclusive with :option:`--html`,
+   :option:`-o`, :option:`--output`.
 
 .. _scripts_ProcessQueue_py:
 

--- a/scripts/printProcessQueue.py
+++ b/scripts/printProcessQueue.py
@@ -87,39 +87,25 @@ if __name__ == '__main__':
 
     dbu = DButils.DButils(options.database)
     items = dbu.ProcessqueueGetAll()
-     
-    # Check if the processque is empty 
-    # Usually used for bash scripts
-    #   return 0 if data exists (true)
-    #   return 1 if processque is empty (false)
-    if options.exist:
-        if items: 
-            print("Process Queue is not empty\n" if not options.quiet else "", end='')
-            del dbu
-            sys.exit(0)
+
+    if not options.quiet:
+        traceback = []
+        for v in items:
+            traceback.append(dbu.getTraceback('File', v))
+
+        if options.html:
+            out = output_html(traceback)
         else:
-            del dbu
-            sys.exit(1)
+            out = output_text(traceback)
 
-    # return the number of items in processqueue 
-    if options.count:
-         print("Number of items in processqueue %d\n" % len(items) if not options.quiet else "", end='')
-         del dbu
-         sys.exit(len(items))
-
-    traceback = []
-    for v in items:
-        traceback.append(dbu.getTraceback('File', v))
-
-    if options.html:
-        out = output_html(traceback)
-    else:
-        out = output_text(traceback)
-
-    if options.output is None:
-        print(out)
-    else:
-        output = open(options.output, 'w')
-        output.write(out)
-        output.close()
+        if options.output is None:
+            print(out)
+        else:
+            output = open(options.output, 'w')
+            output.write(out)
+            output.close()
     del dbu
+    if options.exist:
+        sys.exit(not(items))
+    if options.count:
+        sys.exit(min(len(items), 255))

--- a/scripts/printProcessQueue.py
+++ b/scripts/printProcessQueue.py
@@ -66,24 +66,22 @@ def output_text(items):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("--html", action='store_true',
-                        help="Output in html",
-                        default=False)
-    parser.add_argument("-e", "--exist",  action='store_true',
-                        help="return 1 if processqueue is empty 0 otherwise",
-                        default=False)
+                        help="Output in html")
     parser.add_argument("-q", "--quiet",  action='store_true',
-                        help="Do not display output", 
-                        default=False)
-    parser.add_argument("-c", "--count", action='store_true',
-                        help="Count how many files in the process queue", 
-                        default=False)
+                        help="Do not display output")
     parser.add_argument("-o", "--output",
                         help="Write output to a file")
     parser.add_argument(
         'database', action='store', type=str,
         help='Name of database (or sqlite file), i.e. mission, to open.')
-
+    returncode = parser.add_mutually_exclusive_group()
+    returncode.add_argument("-e", "--exist",  action='store_true',
+                            help="Exit code 1 if queue empty; 0 (True) if not.")
+    returncode.add_argument("-c", "--count", action='store_true',
+                            help="Set exit code to count of files in queue.")
     options = parser.parse_args()
+    if options.quiet and (options.html or options.output):
+        parser.error('--html and -o are useless with -q.')
 
     dbu = DButils.DButils(options.database)
     items = dbu.ProcessqueueGetAll()

--- a/scripts/printProcessQueue.py
+++ b/scripts/printProcessQueue.py
@@ -89,21 +89,13 @@ if __name__ == '__main__':
     items = dbu.ProcessqueueGetAll()
 
     if not options.quiet:
-        traceback = []
-        for v in items:
-            traceback.append(dbu.getTraceback('File', v))
-
-        if options.html:
-            out = output_html(traceback)
-        else:
-            out = output_text(traceback)
-
+        traceback = [dbu.getTraceback('File', v) for v in items]
+        out = (output_html if options.html else output_text)(traceback)
         if options.output is None:
             print(out)
         else:
-            output = open(options.output, 'w')
-            output.write(out)
-            output.close()
+            with open(options.output, 'w') as output:
+                output.write(out)
     del dbu
     if options.exist:
         sys.exit(not(items))


### PR DESCRIPTION
## PR Checklist

Adding options to printProcessQueue as we talked about. Closes #87.

* exist return 0 if there are files in processQueue otherwise 0
* count return the number of files in the processing queue.
* quiet option des not print any message on the screen.

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] Major new functionality has appropriate Sphinx documentation
- [X] Added an entry to release notes if fixing a major bug or providing a major new feature
- [X] (see below) New features and bug fixes should have unit tests
- [X] Relevant issues are linked in the description (use `Closes #` if this PR closes the issue, or some other reference, such as `See #` if it is related in some other way)

Because this script isn't incorporated into unit tests yet, this was hand-tested.


