### PR TITLE
 Only use products that exist on disk when figuring inputs

### DIFF
--- a/dbprocessing/dbprocessing.py
+++ b/dbprocessing/dbprocessing.py
@@ -296,11 +296,13 @@ class ProcessQueue(object):
                 start = dt - datetime.timedelta(days=y)
                 end = dt + datetime.timedelta(days=t)
 
-                filegetter = self.dbu.getFilesByProductTime \
-                             if timebase in ('DAILY',) \
-                             else self.dbu.getFilesByProductDate
-                tmp_files = filegetter(iprod_id, [start, end], newest_version=True)
-                if debug: print("23:    {0}: self.dbu.getFilesByProductDate, {1} {2} {3}".format(time.time() - T0, iprod_id, dt, tmp_files))
+                kwargs = {'startTime': start, 'endTime': end} \
+                         if timebase in ('DAILY',) \
+                         else {'startDate': start, 'endDate': end}
+                tmp_files = self.dbu.getFiles(
+                    product=iprod_id, newest_version=True, exists=True,
+                    **kwargs)
+                if debug: print("23:    {0}: self.dbu.getFiles, {1} {2} {3}".format(time.time() - T0, iprod_id, dt, tmp_files))
                 T0 = time.time()
 
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -51,6 +51,12 @@ quality version of child files (rather than assuming children were up-to-date
 and failing to reprocess them). (`63 <https://github.com/spacepy/dbprocessing/
 pull/63>`_)
 
+Fixed :meth:`~dbprocessing.dbprocessing.ProcessQueue.buildChildren`
+(specifically, helper method ``_getRequiredProducts``) to only look
+for files which are recorded in the database as existing on disk. Most
+notably, this means :ref:`ProcessQueue.py <scripts_ProcessQueue_py>`
+will not attempt to use nonexistent files as inputs to processing.
+
 Other changes
 ^^^^^^^^^^^^^
 

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -315,6 +315,8 @@ Prints the process queue.
 .. option:: -o, --output The name of the file to output to(if blank, print to stdout)
 .. option:: --html Output in HTML
 
+.. _scripts_ProcessQueue_py:
+
 ProcessQueue.py
 ---------------
 .. program:: ProcessQueue

--- a/unit_tests/dbp_testing.py
+++ b/unit_tests/dbp_testing.py
@@ -102,7 +102,7 @@ class AddtoDBMixin(object):
                                        yesterday, tomorrow)
 
     def addFile(self, filename, product_id, utc_date=None, version=None,
-                utc_start=None, utc_stop=None):
+                utc_start=None, utc_stop=None, exists=True):
         """Add a file to the database"""
         if utc_date is None:
             utc_date = datetime.datetime.strptime(
@@ -127,7 +127,7 @@ class AddtoDBMixin(object):
             utc_start_time=utc_start,
             utc_stop_time=utc_stop,
             file_create_date=datetime.datetime.now(),
-            exists_on_disk=True,
+            exists_on_disk=exists,
         )
         return fid
 


### PR DESCRIPTION
This PR changes `_getRequiredProducts` to only consider files that are recorded in the database as existing on disk, and thus won't try to use nonexistent files as inputs to processing. Closes #47.

I think I had speculated somewhere that the runMe checks of the command line build would catch trying to build with a nonexistent file. Turns out that's not the case, and I haven't chased that down.

#89 captures additional possible behavior changes that were incidentally mentioned in #47.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary (N/A)
- [X] Any new modules, functions or classes have docstrings consistent with dbprocessing style (N/A)
- [X] Major new functionality has appropriate Sphinx documentation
- [X] Added an entry to release notes if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked in the description (use `Closes #` if this PR closes the issue, or some other reference, such as `See #` if it is related in some other way)
