### PR TITLE
fast_data: skip deleting files that don't exist on disk

### DIFF
--- a/scripts/fast_data.py
+++ b/scripts/fast_data.py
@@ -117,7 +117,7 @@ def reap(dbu, graph, participants, dofiles=False, dorecords=False, verbose=False
     for node in reversed(nodes[:-1]):
         if verbose:
             print(node['filename'])
-        if dofiles:
+        if node['exists_on_disk'] and dofiles:
             fullpath = dbu.getFileFullPath(node['file_id'])
             if archive is None:
                 os.remove(fullpath)


### PR DESCRIPTION
This one-liner fixes an issue with fast_data. It's intended to delete old versions of files but keep their records behind, while setting the exists_on_disk column to indicate it no longer exists.

The problem is with successive runs. It doesn't check this column before trying to delete, so it will delete files it's already deleted.

This PR adds a simple check for this flag and skips the deletion step if the database doesn't think the file exists. If the database thinks it exists and it's not actually there, it still errors--that's a consistentcy problem.

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] (N/A) Major new functionality has appropriate Sphinx documentation
- [X] (N/A) Added an entry to release notes if fixing a major bug or providing a major new feature
- [X] (N/A, see below) New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked in the description (use `Closes #` if this PR closes the issue, or some other reference, such as `See #` if it is related in some other way)

fast_data is currently untested (its functionality really needs to be wrapped up into main dbp), so there's no test on this.