### PR TITLE
Use docutils <0.16 when building docs in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,7 @@ jobs:
        - run:
            command: |
              rm -f ./setup.cfg # So sphinx-build doesn't go in ~/dbUtils
+             pip install --user "docutils<0.16"
              pip install --user sphinx numpy
              pip install --user numpydoc
              make -C sphinx html | tee doc_output.txt


### PR DESCRIPTION
CI is broken: docs won't build. It looks like `pip` is grabbing Sphinx 1.8.5, probably because we're doing the build on Python 2.7. That still gets a pretty new docutils (0.18). Unfortunately docutils changed some structures in 0.16 which made it incompatible with that Sphinx.

Long-term we're going to have to abandon Python 2 for the doc build (and maybe altogether; I was hoping to get out one Python 2 release but that may not happen). In the meantime I'm pinning to an earlier docutils for the CI.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] (N/A) Major new functionality has appropriate Sphinx documentation
- [X] (N/A) Added an entry to release notes if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked in the description (use `Closes #` if this PR closes the issue, or some other reference, such as `See #` if it is related in some other way)
