### PR TITLE
printProcessQueue: add ability to filter by product, sort

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -36,6 +36,9 @@ queue state (`87
 <https://github.com/spacepy/dbprocessing/issues/87>`_, `88
 <https://github.com/spacepy/dbprocessing/pull/88>`_).
 
+Added option :option:`printProcessQueue --product` to filter output
+(`93 <https://github.com/spacepy/dbprocessing/pull/93>`_).
+
 Deprecations and removals
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -36,7 +36,8 @@ queue state (`87
 <https://github.com/spacepy/dbprocessing/issues/87>`_, `88
 <https://github.com/spacepy/dbprocessing/pull/88>`_).
 
-Added option :option:`printProcessQueue --product` to filter output
+Added options :option:`printProcessQueue --product` to filter output
+and :option:`printProcessQueue --sort` to sort output
 (`93 <https://github.com/spacepy/dbprocessing/pull/93>`_).
 
 Deprecations and removals

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -26,15 +26,15 @@ format but are not in database, and symlink them to the incoming directory
 so they can be ingested (`54 <https://github.com/spacepy/dbprocessing/
 pull/54>`_).
 
-Python 3 support was added.  (`77 <https://github.com/spacepy/dbprocessing/
+Python 3 support was added (`77 <https://github.com/spacepy/dbprocessing/
 pull/77>`_).
 
 Added options :option:`printProcessQueue --count`,
 :option:`printProcessQueue --exist`, and :option:`printProcessQueue
 --quiet` to allow flow control in shell scripts based on the process
-queue state. (`87
+queue state (`87
 <https://github.com/spacepy/dbprocessing/issues/87>`_, `88
-<https://github.com/spacepy/dbprocessing/pull/88>`_)
+<https://github.com/spacepy/dbprocessing/pull/88>`_).
 
 Deprecations and removals
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -352,7 +352,13 @@ Prints the process queue.
 .. option:: -q, --quiet
 
    Quiet mode: produce no output. Mutually exclusive with :option:`--html`,
-   :option:`-o`, :option:`--output`.
+   :option:`-o`, :option:`--output`, :option:`-s`, :option:`--sort`.
+
+.. option:: -s, --sort
+
+   Sort the output. Primary sort by UTC file date, secondary by product name.
+   Default is to output by the order in the process queue, i.e., the order
+   in which files are considered for processing.
 
 .. _scripts_ProcessQueue_py:
 

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -340,6 +340,15 @@ Prints the process queue.
 
    The name of the file to output to (if not specified, output to stdout).
 
+.. option:: -p product [product ...], --product product [product ...]
+
+   Product IDs or name to include in output. May specify multiple products;
+   all other products will be ignored (not included in output or :option:`-c`
+   and :option:`-e` counts). Because this may be used to specify multiple
+   (space-separated) options, use ``--`` to end the list of products before
+   specifying the database (or use ``-p`` as the last option). Adds a table of
+   included products to the output, before the queue output itself.
+
 .. option:: -q, --quiet
 
    Quiet mode: produce no output. Mutually exclusive with :option:`--html`,

--- a/scripts/printProcessQueue.py
+++ b/scripts/printProcessQueue.py
@@ -51,7 +51,7 @@ def output_html(items, products=None):
         output += "    </table>\n"
     output += '    <h2>{0}</h2>\n'.format('processQueue')
     output +="""    <table>
-        <tr><th>file_id</th><th>filename</th><th>product</th></tr>
+        <tr><th>file #</th><th>filename</th><th>product</th></tr>
 """
     for index, item in enumerate(items):
         if( index % 2 == 0 ):


### PR DESCRIPTION
This PR adds two options to `printProcessQueue` to help with scriptability.

The `-p`/`--product` option filters the output by product (either name or ID). This affects the output and also the `-c` and `-e` options. This doesn't just filter the output...it also adds a table of all the included products. So that does make parsing the output a little harder: basically everything up to the line that actually says "ProcessQueue" needs to be ignored.

The `-s`/`--sort` option sorts the output. Primary sort is by date, and secondary is by product _name_. I'm happy to switch this around to whatever is convenient for @dnadeau-lanl : making date secondary, doing product ID instead of name, etc.

Also, the HTML output mislabeled a column as "file ID"...it was a simple index (0, 1, 2....), not the file ID. I changed the label rather than behavior (although the actual file ID might be useful.)

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] Major new functionality has appropriate Sphinx documentation
- [X] Added an entry to release notes if fixing a major bug or providing a major new feature
- [X] (see below) New features and bug fixes should have unit tests
- [X] Relevant issues are linked in the description (use `Closes #` if this PR closes the issue, or some other reference, such as `See #` if it is related in some other way)

As in #88 , this was hand-tested.
