### PR TITLE
Force empty output products to null (Closes #95)

### DIFF
--- a/dbprocessing/DButils.py
+++ b/dbprocessing/DButils.py
@@ -902,7 +902,7 @@ class DButils(object):
             raise ValueError("output_timebase invalid choice")
 
         p1 = self.Process()
-        p1.output_product = output_product
+        p1.output_product = Utils.toNone(output_product)
         p1.process_name = process_name
         p1.extra_params = Utils.toNone(extra_params)
         p1.output_timebase = output_timebase

--- a/unit_tests/test_DButils.py
+++ b/unit_tests/test_DButils.py
@@ -83,6 +83,17 @@ class DBUtilsEmptyTests(TestSetup):
         self.assertEqual('/rootdir/errors', self.dbu.getErrorPath())
         self.assertEqual('/rootdir', self.dbu.getInspectorDirectory())
 
+    def test_addProcessNoOutput(self):
+        """Add a process with no output product"""
+        # This needs to be on "empty" db because our test non-empty
+        # doesn't allow null output product (old database)
+        pid = self.dbu.addProcess('no_output1', '', 'RUN')
+        self.assertIsNone(self.dbu.getEntry('Process', pid).output_product)
+        pid = self.dbu.addProcess('no_output2', None, 'RUN')
+        self.assertIsNone(self.dbu.getEntry('Process', pid).output_product)
+        pid = self.dbu.addProcess('no_output3', 0, 'RUN')
+        self.assertEqual(0, self.dbu.getEntry('Process', pid).output_product)
+
 
 class DBUtilsOtherTests(TestSetup):
     """Tests that are not processqueue or get or add"""


### PR DESCRIPTION
This PR changes ``DButils.addProcess`` such that, if it is passed an empty string for the output product, it inserts null (``None``) into the database. This matches the handling of some other things which may be empty strings in the config file but null in the database, most notably extra arguments for processes. It fixes processes with no output product on postgresql and closes #95.

There is still some code in ``DButils.getChildTree`` to support databases (sqlite) where the column is an empty string, and those shouldn't be removed until #7 is closed (so that "version 1" database will not have the empty string there.)

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] (N/A) Major new functionality has appropriate Sphinx documentation
- [X] (N/A, see below) Added an entry to release notes if fixing a major bug or providing a major new feature
- [X] (also see below) New features and bug fixes should have unit tests
- [X] Relevant issues are linked in the description (use `Closes #` if this PR closes the issue, or some other reference, such as `See #` if it is related in some other way)

I'm not making a release note entry because I'm considering this part of the greater project of getting postgres support going...this most likely would have been found, for instance, if we had the unit tests going on postgres, which continues on my agenda.

Testing is in the unit test, but the functionality in postgres was tested explicitly using the PSP/ISOIS config, which has several processes of this sort:
```sh
createdb dbp -U postgres
export PGUSER=postgres
export PGDATABASE=dbp
python ./CreateDB.py -d postgresql dbp
python ./addFromConfig.py -m dbp ~/scm/isois/glue/dbp_config/psp_dbprocessing.conf 
```
Then verified with ``psql`` that the column was null:
```
$ psql -U postgres
dbp=# select * from process where output_timebase = 'RUN';
```