### PR TITLE
test_DButils: clarify no-output tests

### DIFF
--- a/unit_tests/test_DButils.py
+++ b/unit_tests/test_DButils.py
@@ -91,7 +91,8 @@ class DBUtilsEmptyTests(TestSetup):
         self.assertIsNone(self.dbu.getEntry('Process', pid).output_product)
         pid = self.dbu.addProcess('no_output2', None, 'RUN')
         self.assertIsNone(self.dbu.getEntry('Process', pid).output_product)
-        pid = self.dbu.addProcess('no_output3', 0, 'RUN')
+        # Verify product ID of zero isn't smashed
+        pid = self.dbu.addProcess('output_pid_zero', 0, 'DAILY')
         self.assertEqual(0, self.dbu.getEntry('Process', pid).output_product)
 
 


### PR DESCRIPTION
Tiny PR relevant to discussion in #94, to clarifly the zero output product ID in a test is meant to verify the fix didn't introduce a regression, it's not actually a no-output process

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] (N/A) Major new functionality has appropriate Sphinx documentation
- [X] (N/A) Added an entry to release notes if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked in the description (use `Closes #` if this PR closes the issue, or some other reference, such as `See #` if it is related in some other way)
