### PR TITLE
Close DBrunner db on exit; document the need to close

### DIFF
--- a/dbprocessing/DButils.py
+++ b/dbprocessing/DButils.py
@@ -119,6 +119,15 @@ class DButils(object):
 
     All of these may be user called but are meant to
     be internal routines for DBProcessing
+
+    .. warning::
+       It is strongly encouraged to make sure the database is closed before
+       the program terminates, either by calling :meth:`closeDB` or deleting
+       instances of this object (with an explicit :ref:`del <del>` or by
+       allowing it to go out of scope.) If this object still exists at
+       interpreter exit, it will attempt to close the database, but the
+       functionality to do so may have already been torn down. See for
+       example `Python issue 39513 <https://bugs.python.org/issue39513>`_.
     """
 
     def __init__(self, mission='Test', db_var=None, echo=False, engine=None):

--- a/dbprocessing/dbprocessing.py
+++ b/dbprocessing/dbprocessing.py
@@ -35,6 +35,12 @@ class ProcessQueue(object):
     @contact: balarsen@lanl.gov
 
     @version: V1: 02-Dec-2010 (BAL)
+
+    .. warning::
+       As this object holds a reference to
+       :class:`~dbprocessing.DButils.DButils`, that database should be
+       closed before the program terminates. Deleting this object will
+       ordinarily suffice.
     """
 
     def __init__(self,

--- a/dbprocessing/runMe.py
+++ b/dbprocessing/runMe.py
@@ -286,6 +286,13 @@ class runMe(object):
     utc_file_date - datetime.date
     process_id - process to run (int)
     input_files - the files that exist to run with (list of int)
+
+    .. warning::
+       As this object holds a reference to
+       :class:`~dbprocessing.DButils.DButils`, both directly and within
+       a reference to :class:`~dbprocessing.dbprocessing.ProcessQueue`,
+       that database should be closed before the program terminates.
+       Deleting this object will ordinarily suffice.
     """
     def __init__(self, dbu, utc_file_date, process_id, input_files, pq, version_bump = None, force=False):
         DBlogging.dblogger.debug("Entered runMe {0}, {1}, {2}, {3}".format(dbu, utc_file_date, process_id, input_files))

--- a/scripts/DBRunner.py
+++ b/scripts/DBRunner.py
@@ -174,4 +174,6 @@ if __name__ == "__main__":
                        version_bump=options.force, update=options.update)
     runMe.runner(runme, pq.dbu, MAX_PROC=options.numproc,
                  rundir=None if options.ingest else '.')
-                
+    # Close database by removing all references
+    del runme  # All runMe objects w/references to pq and its DButils
+    del pq  # pq and reference to its DButils


### PR DESCRIPTION
The `__del__` method of `DButils` tries to close the database (and log this closure) as a convenience for the user. Unfortunately if the `DButils` object is still hanging around at program termination, it will be deleted then, and the Python interpreter may have already torn down the logger, and potentially other facilities needed to close the database. The order in which things are torn down is not guaranteed.

This manifests in `DBRunner.py` since it fails to close the database. I've managed to whack-a-mole away most of the other instances but missed that one.

This PR:

- Fixes DBRunner to clean up before exit
- Adds documentation to `DButils` recommending cleaning up before exit, and also on `runMe` and `ProcessQueue`, since they hold references to `DButils`.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] (N/A) Major new functionality has appropriate Sphinx documentation
- [X] (N/A) Added an entry to release notes if fixing a major bug or providing a major new feature
- [X] (see below) New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked in the description (use `Closes #` if this PR closes the issue, or some other reference, such as `See #` if it is related in some other way)

As this bug is nondeterministic, it can't really be unit tested. Similar treatments have cleared up issues in other cases.
