### PR TITLE
Fix python 3.9 and sqlalchemy 1.4 deprecations

### DIFF
--- a/dbprocessing/DButils.py
+++ b/dbprocessing/DButils.py
@@ -9,9 +9,12 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import collections
+try:
+    import collections.abc
+except ImportError:  # Python 2
+    collections.abc = collections
 import datetime
 import getpass
-import pdb
 import glob
 import itertools
 import os
@@ -19,7 +22,6 @@ import os.path
 import posixpath
 import socket  # to get the local hostname
 import sys
-from collections import namedtuple
 from operator import itemgetter, attrgetter
 try:
     import urllib.parse  # python 3
@@ -496,7 +498,7 @@ class DButils(object):
         """
         # if the input is a file name need to handle that
         if isinstance(item, str_classes) \
-           or not isinstance(item, collections.Iterable):
+           or not isinstance(item, collections.abc.Iterable):
             item = [item]
         for ii, v in enumerate(item):
             item[ii] = self.getFileID(v)
@@ -818,7 +820,7 @@ class DButils(object):
         """
         # if not an iterable make it a iterable
         if isinstance(filename, str_classes) \
-           or not isinstance(filename, collections.Iterable):
+           or not isinstance(filename, collections.abc.Iterable):
             filename = [filename]
 
         for ii, f in enumerate(filename):
@@ -2673,7 +2675,8 @@ class DButils(object):
             :sql:column:`~inspector.arguments`, and
             :sql:column:`~inspector.product`.
         """
-        activeInspector = namedtuple('activeInspector', 'path description arguments product_id')
+        activeInspector = collections.namedtuple(
+            'activeInspector', 'path description arguments product_id')
         sq = self.session.query(self.Inspector).filter(self.Inspector.active_code == True).all()
         return [activeInspector(
             os.path.join(
@@ -3536,7 +3539,7 @@ class DButils(object):
             (but not if name lookup is not available).
         """
         retval = None
-        if isinstance(args, (int, collections.Iterable)) \
+        if isinstance(args, (int, collections.abc.Iterable)) \
            and not isinstance(args, str_classes):  # PK: int, non-str sequence
             retval = self.session.query(getattr(self, table)).get(args)
         if retval is None:  # Not valid PK type, or PK not found

--- a/dbprocessing/DButils.py
+++ b/dbprocessing/DButils.py
@@ -565,7 +565,7 @@ class DButils(object):
 
         fileid = (self.session.query(self.File.file_id)
                   .filter(self.File.file_id.in_(fileid))
-                  .filter(~self.File.file_id.in_(subq))).all()
+                  .filter(~self.File.file_id.in_(subq.select()))).all()
 
         fileid = list(map(itemgetter(0), fileid))  # nested tuples to list
 

--- a/dbprocessing/Utils.py
+++ b/dbprocessing/Utils.py
@@ -11,6 +11,10 @@ try:
 except ImportError: # Py2
     import ConfigParser as configparser
 import collections
+try:
+    import collections.abc
+except ImportError:  # Python 2
+    collections.abc = collections
 import datetime
 import errno
 import os
@@ -281,7 +285,8 @@ def flatten(l):
         Flattened list
     """
     for el in l:
-        if isinstance(el, collections.Iterable) and not isinstance(el, str_classes):
+        if isinstance(el, collections.abc.Iterable)\
+           and not isinstance(el, str_classes):
             for sub in flatten(el):
                 yield sub
         else:

--- a/dbprocessing/runMe.py
+++ b/dbprocessing/runMe.py
@@ -153,16 +153,16 @@ def _start_a_run(runme):
     files2poke = _extract_files(runme.cmdline)
     for f in files2poke:
         ans = _pokeFile(f)
-        if ans is 'NOFILE':
+        if ans == 'NOFILE':
             DBlogging.dblogger.error("Command line referenced a file that did not exist {0}.  {1}"
                                      .format(f, runme.cmdline))
-        elif ans is 'OTHER':
+        elif ans == 'OTHER':
             DBlogging.dblogger.error("Command line referenced a file that did 'other' {0}.  {1}"
                                      .format(f, runme.cmdline))
-        elif ans is 'ERROR':
+        elif ans == 'ERROR':
             DBlogging.dblogger.error("Command line referenced a file that did not open {0}.  {1}"
                                      .format(f, runme.cmdline))
-        elif ans is 'FILE':
+        elif ans == 'FILE':
             DBlogging.dblogger.debug("Command line referenced a file opened fine {0}.  {1}"
                                      .format(f, runme.cmdline))
         else:

--- a/scripts/makeLatestSymlinks.py
+++ b/scripts/makeLatestSymlinks.py
@@ -8,6 +8,10 @@ from __future__ import print_function
 
 import argparse
 import collections
+try:
+    import collections.abc
+except ImportError:  # Python 2
+    collections.abc = collections
 import datetime
 import glob
 from pprint import pprint
@@ -115,10 +119,10 @@ def make_symlinks(files, files_out, outdir, linkdirs, mode, options):
     for all the files make symlinks into outdir
     """
     if isinstance(files, dbprocessing.DButils.str_classes) \
-           or not isinstance(files, collections.Iterable):
+           or not isinstance(files, collections.abc.Iterable):
         files = [files]
     if isinstance(files_out, dbprocessing.DButils.str_classes) \
-           or not isinstance(files_out, collections.Iterable):
+           or not isinstance(files_out, collections.abc.Iterable):
         files_out = [files_out]
     # if files_out then cull the files to get rid of the ones
     for f in files:

--- a/scripts/newestVersionProblemFinder.py
+++ b/scripts/newestVersionProblemFinder.py
@@ -84,7 +84,9 @@ def _makeVersionnumSubquery(dbu, prod_id=None):
     version = _makeVersionnumTable(dbu=dbu, prod_id=prod_id)
 
     subq = (dbu.session.query(func.max(version.c.versionnum))
-            .group_by(version.c.utc_file_date)).subquery()
+            .group_by(version.c.utc_file_date))
+    subq = subq.scalar_subquery() if hasattr(subq, 'scalar_subquery')\
+           else subq.subquery().as_scalar() # Deprecated 1.4
     return subq
 
 def oldGetFilesByProduct(dbu, prod_id, newest_version=False):

--- a/unit_tests/test_tables.py
+++ b/unit_tests/test_tables.py
@@ -14,6 +14,7 @@ import tempfile
 import unittest
 
 import sqlalchemy
+import sqlalchemy.inspection
 
 import dbp_testing
 
@@ -54,8 +55,9 @@ class TableDefnTests(unittest.TestCase):
                 name, self.metadata, *dbprocessing.tables.definition(name))
             for name in tables}
         self.metadata.create_all()
-        self.assertEqual(
-            sorted(tables), sorted(self.engine.table_names()))
+        actual = sqlalchemy.inspection.inspect(self.engine)\
+                 .get_table_names()
+        self.assertEqual(sorted(tables), sorted(actual))
         return created
 
     def testFile(self):


### PR DESCRIPTION
This PR fixes deprecations for Python 3.9 (some of which would be errors in 3.10) and for sqlalchemy 1.4. Maintains support on earlier Python and sqlalchemy. Closes #83.

For Python 3.9/3.10:
- imports abstract base classes from `collections.abc` if possible (fallback to `collections`)
- Replaces `is` string comparisons with `==`
- A little bit of style cleanup in directly-related lines

For sqlalchemy 1.4:
- `table_names()` was removed (affects tests only)
- `mapped_table` was replaced with `persist_selectable` (affects tests only)
- Make a subquery into an explicit selection (`DButils`)
- Make a subquery into an explicitly scalar subquery (`newestVersionProblemFinder`, which is untested)

This supersedes #84, which does not fix all warnings in #83 and didn't preserve namespacing on `collections`.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] (N/A) Major new functionality has appropriate Sphinx documentation
- [X] (N/A) Added an entry to release notes if fixing a major bug or providing a major new feature
- [X] (see below) New features and bug fixes should have unit tests
- [X] Relevant issues are linked in the description (use `Closes #` if this PR closes the issue, or some other reference, such as `See #` if it is related in some other way)

We don't yet have unit tests to make sure warnings aren't raised, and I didn't add them. But the tests now pass without warnings on Python 3.10 and sqlalchemy 1.4.
