### PR TITLE
Provide support documentation integrated with GitHub and other doc tweaks

### DIFF
--- a/docs/CONTRIBUTING.rst
+++ b/docs/CONTRIBUTING.rst
@@ -7,10 +7,16 @@ requests, and other feedback are welcome via
 issue, a template is provided to assist in capturing all the
 information needed.
 
+If you are unsure whether something is a bug, would like support with
+your use case, or just for general less-structured help, open a
+conversation at
+<https://github.com/spacepy/dbprocessing/discussions>. From these
+discussions the dbprocessing team can assist in formalizing issues.
+
 To submit changes to code or documentation, open a pull request at
 <https://github.com/spacepy/dbprocessing/pulls>. Pull requests also
 have templates to help with the structure. If you are planning a
-particularly major change, please first open an issue for discussion
+particularly major change, please first open an issue for scoping and design
 at <https://github.com/spacepy/dbprocessing/issues>. Label with
 ``enhancement`` and, if you have questions about implementation, also
 with ``question``.

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -13,6 +13,16 @@ to process data files to derived products, and input files themselves,
 ``dbprocessing`` iteratively runs the appropriate codes to make all
 possible output files.
 
+``dbprocessing`` delegates the details of producing files to
+mission-specific processing codes.  A processing code must have a
+command-line interface and produce a single output file from one or
+more inputs. There are no language restrictions; dbprocessing has been
+used with C, Interactive Data Language (IDL), Java, and Python.
+
+Support for a file format requires about 30 lines of Python to
+identify the product and extract required metadata, which can support
+many different products
+
 When new versions of codes or input files are provided, codes are re-run
 to ensure all outputs are up to date.
 

--- a/docs/SUPPORT.rst
+++ b/docs/SUPPORT.rst
@@ -1,0 +1,20 @@
+Getting help
+============
+
+Primary support is via Q&A discussions in the dbprocessing GitHub
+repository at
+<https://github.com/spacepy/dbprocessing/discussions/categories/q-a>.
+
+It is recommended to search all discussions as well at the issues at
+<https://github.com/spacepy/dbprocessing/issues>; your question may
+have already been answered by someone else.
+
+Full documentation is at <https://spacepy.github.io/dbprocessing>.
+
+Structured bug reports or enhancement requests can be submitted at
+<https://github.com/spacepy/dbprocessing/issues>. This is recommended
+if you have a concretely defined bug with good instructions for
+reproducing, or well-scoped enhancement. Otherwise opening a
+discussion is recommended, at
+<https://github.com/spacepy/dbprocessing/discussions>. The
+dbprocessing team can work with you to refine the issue.

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -11,8 +11,19 @@
 {%- endblock %}
 
 {% block rootrellink %}
+        <li><a href="https://spacepy.github.io/dbprocessing/">homepage</a>|&nbsp;</li>
+        <li><a href="{{ pathto('SUPPORT') }}">help</a>|&nbsp;</li>
+        <li><a href="https://github.com/spacepy/dbprocessing">development</a>|&nbsp;</li>
         <li><a href="{{ pathto('search') }}">search</a>|&nbsp;</li>
-       <li><a href="{{ pathto('index') }}">top</a> &raquo;</li>
+        <li><a href="{{ pathto('index') }}">docs</a> &raquo;</li>
+{% endblock %}
+
+{% block relbar1 %}
+
+<div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px">
+<a href="{{ pathto('index') }}"><h1>dbprocessing</h1></a>
+</div>
+{{ super() }}
 {% endblock %}
 
 {# put the sidebar before the body #}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -167,7 +167,7 @@ html_theme_options = { 'sidebarwidth': '350' }
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+html_title = "%s v%s manual" % (project, version)
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None

--- a/docs/developer/documentation.rst
+++ b/docs/developer/documentation.rst
@@ -117,6 +117,10 @@ These documentation files are "magic" to github:
      (:doc:`../LICENSE`)
    * README
      (:doc:`../README`)
+   * `SUPPORT <https://docs.github.com/en/communities/
+     setting-up-your-project-for-healthy-contributions/
+     adding-support-resources-to-your-project>`_
+     (:doc:`../SUPPORT`)
 
 The github documentation on `community profiles
 <https://docs.github.com/en/communities/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,6 @@
-############
-dbprocessing
-############
+##########################
+dbprocessing documentation
+##########################
 .. toctree::
    :maxdepth: 1
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,16 @@
 ##########################
 dbprocessing documentation
 ##########################
+``dbprocessing`` automates the routine data processing needs arising
+in every Heliophysics mission. This Python-based, database-driven
+process controller uses the arrival of new data to automatically
+execute relevant processing codes, providing updated files for all
+possible data products.
+
+Although originally written for Heliophysics data, it is intended to
+be flexible enough to manage most forms of digital time-dependent
+data.
+
 .. toctree::
    :maxdepth: 1
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,6 +5,7 @@ dbprocessing
    :maxdepth: 1
 
    README
+   SUPPORT
    getting_started
    concepts
    release_notes


### PR DESCRIPTION
This PR provides a link to the GitHub page in the doc header and provides a "how to get support" page, thus closes #118. It also does a few general doc cleanups:

- Changes the HTML title (to "dbprocessing manual") and the title on the front docs page
- Add "dbprocessing" to the main header for each page
- Updates the README to include some language from the proposal that makes things a bit more clear, and adopt some language from the README for the front-page of the docs so it's not just a bullet list of doc titles.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] (N/A) Major new functionality has appropriate Sphinx documentation
- [X] (N/A) Added an entry to release notes if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked in the description (use `Closes #` if this PR closes the issue, or some other reference, such as `See #` if it is related in some other way)
