### PR TITLE
docs: link the website from README

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -6,6 +6,8 @@ input data. Although originally written for Heliophysics data, it is
 intended to be flexible enough to manage most forms of digital time-series
 data.
 
+Documentation is available at <https://spacepy.github.io/dbprocessing/>.
+
 What dbprocessing does
 ----------------------
 Given a description of relationship between data files, a set of codes


### PR DESCRIPTION
#122 made it easier to get to the GitHub page from the website/built documentation. But from the GitHub page, the website isn't obvious. This PR just adds a link from the README so people looking at the repository can get linked to the built docs.

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] (N/A) Major new functionality has appropriate Sphinx documentation
- [X] (N/A) Added an entry to release notes if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked in the description (use `Closes #` if this PR closes the issue, or some other reference, such as `See #` if it is related in some other way)
