### PR TITLE
Update 0.1.0 release notes

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -211,6 +211,8 @@ PR `122 <https://github.com/spacepy/dbprocessing/pull/122>`_: Provide support do
 
 PR `123 <https://github.com/spacepy/dbprocessing/pull/123>`_: Updates for release 0.1.0
 
+    `5 <https://github.com/spacepy/dbprocessing/issues/5>`_: Script installation into default location
+
 PR `124 <https://github.com/spacepy/dbprocessing/pull/124>`_: Updated docs for release 0.1.0
 
 Other issues closed this release

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -209,11 +209,11 @@ PR `122 <https://github.com/spacepy/dbprocessing/pull/122>`_: Provide support do
 
     `118 <https://github.com/spacepy/dbprocessing/issues/118>`_: Link github page in documentation
 
-PR `123 <https://github.com/spacepy/dbprocessing/pull/123>`_: Updates for release 0.1.0
+PR `123 <https://github.com/spacepy/dbprocessing/pull/123>`_: Updates for release 0.1.0 (`5acdfa8d <https://github.com/spacepy/dbprocessing/commit/5acdfa8d6d33d7001660120790b634f5079148d5>`_)
 
     `5 <https://github.com/spacepy/dbprocessing/issues/5>`_: Script installation into default location
 
-PR `124 <https://github.com/spacepy/dbprocessing/pull/124>`_: Updated docs for release 0.1.0
+PR `124 <https://github.com/spacepy/dbprocessing/pull/124>`_: Updated docs for release 0.1.0 (`a474d582 <https://github.com/spacepy/dbprocessing/commit/a474d582616c6f8d795f6cc165be67b2834ba904>`_)
 
 Other issues closed this release
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR contains two small changes to the 0.1.0 release notes. I don't intend to rebuild the website docs or release for 0.1.0 for these, but these make the history in there more accurate.

- #5 was closed and not included in the release notes, so that was added
- The final commit hashes for #123 and #124 obviously weren't available at the time the PRs were open, so added them now. This will always be a little bit of an issue, since the release notes "should" reference the PR with the final release, but putting the hash in the release notes will change the hash...for now I'm just thinking in terms of slapping in an update after the fact, like this, but there may be other options.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A)  Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] (N/A)  Major new functionality has appropriate Sphinx documentation
- [X] (N/A)  Added an entry to release notes if fixing a major bug or providing a major new feature
- [X] (N/A)  New features and bug fixes should have unit tests
- [X] Relevant issues are linked in the description (use `Closes #` if this PR closes the issue, or some other reference, such as `See #` if it is related in some other way)
