### PR TITLE
CI: use sqlalchemy before 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
              pip install --user python-dateutil
              sudo apt update
              sudo apt install python3-pip
-             pip3 install --user sqlalchemy
+             pip3 install --user "sqlalchemy<2.0"
              pip3 install --user python-dateutil
        - persist_to_workspace:
            root: ~/.local


### PR DESCRIPTION
As noted in #130 and #135, dbp currently uses the old syntax for SQLAlchemy which went away in 2.0. Short-term, all this PR does is keep the CI against pre-2.0 so that we're not dead in the water while working on #135.

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] (N/A) Major new functionality has appropriate Sphinx documentation
- [X] (N/A) Added an entry to release notes if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked in the description (use `Closes #` if this PR closes the issue, or some other reference, such as `See #` if it is related in some other way)
