### PR TITLE
Small typo fixes in documentation

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -87,7 +87,7 @@ responsibility of data processing codes.
 Codes
 =====
 A data processing code, or simply "code", produces an output data file
-from one ore more inputs. There are several requirements on a code:
+from one or more inputs. There are several requirements on a code:
 
    * It must be callable from the command line.
    * It must accept one or more input files and produce a single

--- a/docs/developer/tables.rst
+++ b/docs/developer/tables.rst
@@ -922,7 +922,7 @@ in most cases, return a record from any table.
 
    Describes an satellite. A satellite is primarily a means of connecting
    related products for convenience (e.g. in queries and reprocessing);
-   generally speaking it corresponds to a physical instrument. The hierarchy
+   generally speaking it corresponds to a physical spacecraft. The hierarchy
    of association is :sql:table:`instrument`, :sql:table:`satellite`,
    :sql:table:`mission`, where each relation is many-to-one.
 


### PR DESCRIPTION
Fixes one typo and one braino (referring to a satellite as an "instrument") that I noticed in the documentation.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with dbprocessing style
- [X] (N/A) Major new functionality has appropriate Sphinx documentation
- [X] (N/A) Added an entry to release notes if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked in the description (use `Closes #` if this PR closes the issue, or some other reference, such as `See #` if it is related in some other way)
